### PR TITLE
Method to send New Privly Url to Android Platform added.

### DIFF
--- a/shared/javascripts/extension_integration.js
+++ b/shared/javascripts/extension_integration.js
@@ -45,7 +45,7 @@ var privlyExtension = {
       // iframe.parentNode.removeChild(iframe);
       // iframe = null;
     } else if(privlyNetworkService.platformName() === "ANDROID") {
-	androidJBridge.receiveNewPrivlyURL(url);
+	androidJsBridge.receiveNewPrivlyURL(url);
     }
   }
 };


### PR DESCRIPTION
The androidJSBridge will invoke the function receiveNewPrivlyUrl() as defined in the Javascript Interface Class on Android, which will receive the url. 
