### PR TITLE
Fix Displayed URL

### DIFF
--- a/Login/new.html
+++ b/Login/new.html
@@ -56,7 +56,7 @@
      </div>
      <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
-       <li class="logged_in_nav " style="display:none;">
+       <li class="logged_in_nav" style="display:none;">
         <a href="../Index/new.html">
          Index
         </a>

--- a/PlainPost/new.html
+++ b/PlainPost/new.html
@@ -58,7 +58,7 @@
      </div>
      <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
-       <li class="logged_in_nav " style="display:none;">
+       <li class="logged_in_nav" style="display:none;">
         <a href="../Index/new.html">
          Index
         </a>

--- a/ZeroBin/new.html
+++ b/ZeroBin/new.html
@@ -68,7 +68,7 @@
      </div>
      <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
-       <li class="logged_in_nav " style="display:none;">
+       <li class="logged_in_nav" style="display:none;">
         <a href="../Index/new.html">
          Index
         </a>

--- a/templates/new.html.template
+++ b/templates/new.html.template
@@ -60,7 +60,7 @@
           </div>
           <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
-              <li style="display:none;" class="logged_in_nav {% if name == 'Index' %}active{% endif %}">
+              <li style="display:none;" class="logged_in_nav{% if name == 'Index' %} active{% endif %}">
                 <a href="../Index/new.html">Index</a>
               </li>
               <li class="{% if action == 'new' %}active{% endif %} dropdown logged_in_nav mobile_hide" style="display:none;">


### PR DESCRIPTION
This pull request changes the way Privly-type URLs are displayed in new.html files so that the link the user follows will stay in local code, if possible. Previously the link's href would be set to the local code destination, but users may copy and paste the link in such a way that they copy the local link instead of the shareable link.

This pull request also adds an error message to the login application.
