### PR TITLE
fixed login help links

### DIFF
--- a/Login/js/new.js
+++ b/Login/js/new.js
@@ -25,8 +25,16 @@ var callbacks = {
    */
   pendingLogin: function() {
     
+    // Get the domain the user's extension is paired with
+    var domain = privlyNetworkService.contentServerDomain();
+    
     // Display the content server the user is asssociated with
-    $(".content_server").text(privlyNetworkService.contentServerDomain());
+    $(".content_server").text(domain);
+    
+    $(".login_issue").each( function( key, value ) {
+      $(value).attr("href", domain + $(value).attr("data-path-sub"))
+    });
+    
     
     // Set the nav bar to the proper domain
     privlyNetworkService.initializeNavigation();

--- a/Login/new.html
+++ b/Login/new.html
@@ -191,15 +191,15 @@
       <h2>
        Sign in Issues
       </h2>
-      <a href="/users/password/new">
+      <a class="login_issue" data-path-sub="/users/password/new" href="#" target="_blank">
        Forgot your password?
       </a>
       <br/>
-      <a href="/users/confirmation/new">
+      <a class="login_issue" data-path-sub="/users/confirmation/new" href="#" target="_blank">
        Didn't receive confirmation instructions?
       </a>
       <br/>
-      <a href="/users/unlock/new">
+      <a class="login_issue" data-path-sub="/users/unlock/new" href="#" target="_blank">
        Didn't receive unlock instructions?
       </a>
      </div>

--- a/Login/new.html.subtemplate
+++ b/Login/new.html.subtemplate
@@ -46,11 +46,14 @@
   <hr />
   <div class="col-md-3">
     <h2>Sign in Issues</h2>
-    <a href="/users/password/new">Forgot your password?</a>
+    <a class="login_issue" href="#" target="_blank"
+      data-path-sub="/users/password/new">Forgot your password?</a>
     <br />
-    <a href="/users/confirmation/new">Didn't receive confirmation instructions?</a>
+    <a class="login_issue" href="#" target="_blank"
+      data-path-sub="/users/confirmation/new">Didn't receive confirmation instructions?</a>
     <br />
-    <a href="/users/unlock/new">Didn't receive unlock instructions?</a>
+    <a class="login_issue" href="#" target="_blank"
+      data-path-sub="/users/unlock/new">Didn't receive unlock instructions?</a>
   </div>
   
   <div class="col-md-7">


### PR DESCRIPTION
The links on the login page currently target the extension as the root domain when the privly applications are served by the extension. This fixes the login help links to properly target the content server associated with the user's extension.
