### PR TITLE
Fix for Hide Menu Options from the PrivlyApplications. #16

### DIFF
--- a/shared/css/common.css
+++ b/shared/css/common.css
@@ -353,3 +353,23 @@ pre code {
   background-color: transparent;
   border: 0;
 }
+
+/* Low Resolution Smartphones */
+@media only screen 
+and (min-device-width : 320px) 
+and (max-device-width : 480px) {
+	.navbar-toggle
+	{
+		display:none !important;
+	}
+}
+
+/* High Resolution Smartphones & Tablets */
+@media only screen 
+and (min-device-width : 768px) 
+and (max-device-width : 1024px) {
+	.navbar-toggle
+	{
+		display:none !important;
+	}
+}


### PR DESCRIPTION
Updated the common.css - Out of all the solutions I came across, media queries worked pretty fine and can be used to specifically target device wise class modifications based on the screen sizes. Important tag is just used to enforce this specific property modification to the class even if there are other modifications happening anywhere else to the same class.
As @vshivam suggested to hide the complete menu since we'll be providing navigation options inside the android application itself.
This above fix hides the menu completely.
