### PR TITLE
Use auth tokens to login

### DIFF
--- a/Login/js/new.js
+++ b/Login/js/new.js
@@ -42,7 +42,7 @@ var callbacks = {
     privlyNetworkService.initializeNavigation();
     
     // Monitor the login button
-    document.querySelector("#login").addEventListener('click', callbacks.submitCredentials);
+    document.querySelector('#login').addEventListener('click', callbacks.submitCredentials);
     $("#user_password").keyup(function (e) {
         if (e.keyCode == 13) {
             callbacks.submitCredentials();

--- a/Login/js/new.js
+++ b/Login/js/new.js
@@ -49,15 +49,18 @@ var callbacks = {
         }
     });
 
-    // Toggle the checkbox when the text next to it is clicked
-    document.querySelector("#checkbox_text").addEventListener('click', function() {
-      $("#stayLoggedIn").prop("checked", !$("#stayLoggedIn").prop("checked"));
-    });
+    // If the "stay logged in" button exists
+    if ( $("#checkbox_text").length ) {
+      // Toggle the checkbox when the text next to it is clicked
+      document.querySelector("#checkbox_text").addEventListener('click', function() {
+        $("#stayLoggedIn").prop("checked", !$("#stayLoggedIn").prop("checked"));
+      });
 
-    // Change the cursor when hovering the text next to the checkbox
-    document.querySelector("#checkbox_text").addEventListener('mouseover', function() {
-      $(this).css("cursor", "pointer");
-    });
+      // Change the cursor when hovering the text next to the checkbox
+      document.querySelector("#checkbox_text").addEventListener('mouseover', function() {
+        $(this).css("cursor", "pointer");
+      });
+    }
     
     // Add listeners to show loading animation while making ajax requests
     $(document).ajaxStart(function() {
@@ -91,7 +94,7 @@ var callbacks = {
     $("#save").prop('disabled', true);
 
     // If #stayLoggedIn checkbox is checked, request an authenticaion token to the server
-    if(document.querySelector("#stayLoggedIn").checked) {
+    if( $("#checkbox_text").length && document.querySelector("#stayLoggedIn").checked ) {
       privlyNetworkService.sameOriginPostRequest(
         privlyNetworkService.contentServerDomain() + "/token_authentications.json",
         callbacks.checkCredentials,
@@ -112,12 +115,14 @@ var callbacks = {
    * Check to see if the user's credentials were accepted by the server.
    */
   checkCredentials: function(response) {
-    if ( response.json.success === true || response.textStatus === "success") {
+
+    if ( response.json.error === undefined && response.json.success === true ) {
+      callbacks.pendingPost();
+    } else if( response.json.auth_key !== undefined ) {
       
       // Save the authentication token to localStorage
-      if ( response.json.auth_key !== undefined) {
-        localStorage["authToken"] = response.json.auth_key;
-      }
+      localStorage["authToken"] = response.json.auth_key;
+
       callbacks.pendingPost();
     } else {
       callbacks.loginFailure();

--- a/Login/new.html
+++ b/Login/new.html
@@ -171,6 +171,13 @@
         <br/>
         <input id="user_password" name="user[password]" placeholder="Enter Password" size="30" type="password"/>
        </div>
+       <div class="form-group">
+        <input type="checkbox" id="stayLoggedIn">
+        <span id="checkbox_text"> 
+          Keep me logged in 
+        </span>
+        <br/>
+      </div>
        <br/>
        <div class="form-group">
         <button class="btn btn-default" id="login">

--- a/Login/new.html
+++ b/Login/new.html
@@ -171,13 +171,6 @@
         <br/>
         <input id="user_password" name="user[password]" placeholder="Enter Password" size="30" type="password"/>
        </div>
-       <div class="form-group">
-        <input type="checkbox" id="stayLoggedIn">
-        <span id="checkbox_text"> 
-          Keep me logged in 
-        </span>
-        <br/>
-      </div>
        <br/>
        <div class="form-group">
         <button class="btn btn-default" id="login">

--- a/Login/new.html.subtemplate
+++ b/Login/new.html.subtemplate
@@ -32,7 +32,17 @@
       <input id="user_password" name="user[password]" size="30" 
         type="password" placeholder="Enter Password" />
     </div>
-
+    {%
+      if args.platform == "chrome"
+    %}
+    <div class="form-group">
+      <input type="checkbox" id="stayLoggedIn">
+      <span id="checkbox_text">
+        Keep me logged in
+      </span>
+      <br/>
+    </div>
+    {% endif %}
     <br />
     <div class="form-group">
       <button id="login" class="btn btn-default">Login to 

--- a/shared/javascripts/network_service.js
+++ b/shared/javascripts/network_service.js
@@ -44,6 +44,8 @@ var privlyNetworkService = {
     } else if(privlyNetworkService.platformName() === "ANDROID") {
       privlyNetworkService.authToken = "auth_token=" + 
                                               androidJsBridge.fetchAuthToken();
+    } else if(privlyNetworkService.platformName() === "CHROME") {
+      privlyNetworkService.authToken = "auth_token=" + localStorage["authToken"];
     }
   },
   
@@ -408,7 +410,14 @@ var privlyNetworkService = {
     $(".home_domain").text(domain.split("/")[2]);  
     $(".account_url").attr("href", domain + "/pages/account");
     $(".legal_nav").attr("href", domain + "/pages/privacy");
-    document.getElementById("logout_link").addEventListener('click', function(){
+    document.getElementById("logout_link").addEventListener('click', function() {
+      
+      // Send a DELETE request to the server to remove the authentication token
+      privlyNetworkService.sameOriginDeleteRequest(
+        privlyNetworkService.contentServerDomain() + "/token_authentications.json",
+        function(){},
+        {});  
+
       $.post(domain + "/users/sign_out", "_method=delete", function(data) {
         window.location = "../Login/new.html";
       });

--- a/shared/javascripts/network_service.js
+++ b/shared/javascripts/network_service.js
@@ -44,7 +44,8 @@ var privlyNetworkService = {
     } else if(privlyNetworkService.platformName() === "ANDROID") {
       privlyNetworkService.authToken = "auth_token=" + 
                                               androidJsBridge.fetchAuthToken();
-    } else if(privlyNetworkService.platformName() === "CHROME") {
+    } else if(privlyNetworkService.platformName() === "CHROME" &&
+              localStorage["authToken"] !== undefined) {
       privlyNetworkService.authToken = "auth_token=" + localStorage["authToken"];
     }
   },
@@ -411,15 +412,13 @@ var privlyNetworkService = {
     $(".account_url").attr("href", domain + "/pages/account");
     $(".legal_nav").attr("href", domain + "/pages/privacy");
     document.getElementById("logout_link").addEventListener('click', function() {
-      
-      // Send a DELETE request to the server to remove the authentication token
-      privlyNetworkService.sameOriginDeleteRequest(
-        privlyNetworkService.contentServerDomain() + "/token_authentications.json",
-        function(){},
-        {});  
-
       $.post(domain + "/users/sign_out", "_method=delete", function(data) {
-        window.location = "../Login/new.html";
+
+        // Send a DELETE request to the server to remove the authentication token
+        privlyNetworkService.sameOriginDeleteRequest(
+          privlyNetworkService.contentServerDomain() + "/token_authentications.json",
+          function(){window.location = "../Login/new.html";},
+          {});         
       });
     });
     

--- a/shared/javascripts/network_service.js
+++ b/shared/javascripts/network_service.js
@@ -417,7 +417,13 @@ var privlyNetworkService = {
         // Send a DELETE request to the server to remove the authentication token
         privlyNetworkService.sameOriginDeleteRequest(
           privlyNetworkService.contentServerDomain() + "/token_authentications.json",
-          function(){window.location = "../Login/new.html";},
+          function() {
+            if( privlyNetworkService.platformName() === "CHROME" &&
+                      localStorage["authToken"] !== undefined ) {
+              delete localStorage["authToken"];
+            }
+            window.location = "../Login/new.html";
+          },
           {});         
       });
     });


### PR DESCRIPTION
Users can choose to stay logged in even after the browser is closed. This is achieved using an authentication token requested from the server that is save in localStorage. When the user logs out, the token is removed from the server. 