### PR TITLE
fixed tooltip display on Chrome's first run page

### DIFF
--- a/Pages/ChromeFirstRun.html.subtemplate
+++ b/Pages/ChromeFirstRun.html.subtemplate
@@ -7,8 +7,8 @@
 
 {% block javascripts %}
   <script type="text/javascript" src="../vendor/jquery.min.js"></script>
-  <script src="js/tooltip.js"></script>
-  <script src="js/first_run.js"></script>
+  <script type="text/javascript" src="../shared/javascripts/tooltip.js"></script>
+  <script type="text/javascript" src="js/first_run.js"></script>
 {% endblock %}
 
 {% block css %}

--- a/Pages/js/first_run.js
+++ b/Pages/js/first_run.js
@@ -13,11 +13,13 @@ function init() {
   privlyNetworkService.initializeNavigation();
   $("#messages").hide();
   $("#form").show();
-  privlyTooltip.tooltip();
   privlyNetworkService.showLoggedInNav();
   
   // Show a preview of the tooltip to the user
-  privlyTooltip.tooltip();
+  var glyphHTML = privlyTooltip.glyphHTML();
+  $("#tooltip").html(glyphHTML)
+               .show()
+               .append("<p>This is your Privly Glyph</p>");
 }
 
 // Initialize the application


### PR DESCRIPTION
This pull request fixes the FirstRun page that was broken on Chrome. After merging this into master I will merge it into [Chrome's master](https://github.com/privly/privly-applications/tree/chrome-extension-master) without a pull request.

The problem was that the tooltip was error-ing for the preview window.
