### PR TITLE
Updated platform detection for Firefox

### DIFF
--- a/shared/javascripts/network_service.js
+++ b/shared/javascripts/network_service.js
@@ -97,8 +97,7 @@ var privlyNetworkService = {
       return "ANDROID";
     }  else if (typeof chrome !== "undefined" && typeof chrome.extension !== "undefined") {
       return "CHROME";
-    } else if(typeof Components !== "undefined" &&
-    typeof Components.classes !== "undefined") {
+    } else if(window.location.href.indexOf("chrome://") === 0) {
       return "FIREFOX";
     } else {
       return "HOSTED";


### PR DESCRIPTION
Since the "components" object is deprecated on Firefox, this moves to a more robust method of detecting its platform.
