### PR TITLE
Update Testing for Firefox

### DIFF
--- a/Pages/ChromeOptions.html
+++ b/Pages/ChromeOptions.html
@@ -242,7 +242,7 @@
          </span>
          Add more
         </span>
-        <button class="btn btn-primary btn-sm" id="save">
+        <button class="btn btn-primary btn-sm" id="save_whitelist">
          Save
         </button>
         <br/>

--- a/Pages/ChromeOptions.html.subtemplate
+++ b/Pages/ChromeOptions.html.subtemplate
@@ -79,7 +79,7 @@
       <span class="glyphicon glyphicon-plus-sign"></span> Add more 
     </span>
 
-    <button id="save" class="btn btn-primary btn-sm">Save</button>
+    <button id="save_whitelist" class="btn btn-primary btn-sm">Save</button>
 
     <br />
     <br />

--- a/Pages/js/options.js
+++ b/Pages/js/options.js
@@ -285,7 +285,7 @@ function listeners(){
   document.querySelector('#regenerate_glyph').addEventListener('click', regenerateGlyph);
   
   // Options save button
-  document.querySelector('#save').addEventListener('click', saveWhitelist);
+  document.querySelector('#save_whitelist').addEventListener('click', saveWhitelist);
     
   // content server menu listeners
   document.querySelector('#save_server').addEventListener('click', saveServer);

--- a/test/selenium/run_all.rb
+++ b/test/selenium/run_all.rb
@@ -18,13 +18,26 @@ require 'capybara' # Manages Selenium
 require 'capybara/dsl' # Syntax for interacting with Selenium
 require 'test/unit' # Provides syntax for expectation statements
 
+# Change the directory to this script's directory
+Dir.chdir File.expand_path(File.dirname(__FILE__))
+
 args = {}
+optsHelp = ""
 OptionParser.new do |opts|
-  opts.banner = "Usage: ruby example.rb [options]"
-  opts.on('-p', '--platform PLATFORM', 'The target platform (web, firefox, chrome, etc)') { |v| args[:platform] = v }
+  opts.banner = "Usage: ruby run_all.rb [options]"
+  opts.on('-p', '--platform PLATFORM', 'The target platform (firefox_web, firefox_extension, chrome_web, chrome_extension, sauce_chrome_web, sauce_firefox_web, sauce_firefox_extension, sauce_chrome_extension)') { |v| args[:platform] = v }
   opts.on('-r', '--release-status RELEASE', 'The target release stage (experimental, deprecated, alpha, beta, release)') { |v| args[:release_status] = v }
   opts.on('-c', '--content-server SERVER', 'The content server (http://localhost:3000)') { |v| args[:content_server] = v }
+  optsHelp = opts.help
 end.parse!
+
+# Exit if three arguments were not supplied
+if not args.length == 3
+  puts "\nYou must specify all three arguments\n\n"
+  puts optsHelp
+  exit 0
+end
+
 puts "You passed the arguments: #{args}"
 
 # Defaults
@@ -142,11 +155,11 @@ if platform.include? "firefox_extension"
    Capybara.app_host = "chrome://privly"
    address_start = Capybara.app_host + "/content/privly-applications/"
    puts "Packaging the Firefox Extension"
-   system( "cd ../../../ && ./package.sh && cd chrome/content/privly-applications/" )
+   system( "cd ../../../../../ && pwd && ./package.sh && cd chrome/content/privly-applications/test/selenium" )
 
    # Load the Firefox driver with the extension installed
    @profile = Selenium::WebDriver::Firefox::Profile.new
-   @profile.add_extension("../../../PrivlyFirefoxExtension.xpi")
+   @profile.add_extension("../../../../../PrivlyFirefoxExtension.xpi")
 end
 
 if platform == "firefox_extension"
@@ -249,7 +262,7 @@ if args[:release_status]
 end
 
 # Build the data structure used by some specs to determine what to test
-manifest_files = Dir["*/manifest.json"]
+manifest_files = Dir["../../*/manifest.json"]
 manifest_files.each do |manifest_file|
   json = JSON.load(File.new(manifest_file))
   json.each do |app_manifest|

--- a/test/selenium/specs/auth_helper.rb
+++ b/test/selenium/specs/auth_helper.rb
@@ -8,14 +8,23 @@ module AuthHelper
   # then click on the login button and log the user into the localhost:3000
   # server
   def login(content_server)
+
+    # Default to a user defined on localhost
+    user = "development@priv.ly"
+    password = "password"
+
+    # Give the proper password for the testing user if
+    # testing against production
+    if content_server == "https://privlyalpha.org"
+      user = "danger.dont.use.bork.bork.bork@privly.org"
+      password = "danger.dont.use.bork.bork.bork"
+    end
     setServer = "ls.setItem('posting_content_server_url', '" +
       content_server + "')"
     page.execute_script(setServer)
     page.driver.browser.navigate.refresh
     login_button = page.all(:css, '.login_url')
     login_button[0].click
-    user = "development@priv.ly"
-    password = "password"
     fill_in 'user_email', :with =>  user
     fill_in 'user_password', :with => password
     domain = page.evaluate_script('privlyNetworkService.contentServerDomain()');

--- a/test/selenium/specs/tc_extension_options.rb
+++ b/test/selenium/specs/tc_extension_options.rb
@@ -1,0 +1,78 @@
+# This test class tests whether the extensions options change
+# after they are selected on the options page.
+class TestOptions < Test::Unit::TestCase
+
+  include Capybara::DSL # Provides for Webdriving
+
+  def setup
+    if not @@privly_extension_active
+      return
+    end
+    @current_browser = page.driver.browser.browser.to_s
+    if @current_browser == "firefox"
+      @options_url = "chrome://privly/content/privly-applications/Pages/ChromeOptions.html"
+    elsif @current_browser == "chrome"
+      @options_url = "chrome-extension://gipdbddcenpbjpmjblgmogkeblhoaejd/privly-applications/Pages/ChromeOptions.html"
+    end
+    page.driver.browser.get(@options_url)
+  end
+
+  def test_regenerating_glyph
+    if not @@privly_extension_active
+      return
+    end
+    current_fill = page.all(:css, '.glyph_fill').length
+
+    # todo, make this elegant
+    10.times do
+      click_button('regenerate_glyph')
+      if not current_fill == page.all(:css, '.glyph_fill').length
+       return
+      end
+    end
+    assert false # It probabilistically did not generate a new Glyph
+  end
+
+  def test_update_whitelist
+
+    if not @@privly_extension_active
+      return
+    end
+
+    # Assert nothing is injected before whitelisting
+    page.driver.browser.get("http://test.privly.org/test_pages/nonwhitelist.html")
+    assert page.has_no_xpath?('//iframe')
+
+    # Update the whitelist
+    page.driver.browser.get(@options_url)
+    elements = page.all(:css, '.whitelist_url')
+    elements[0].set 'Dev.Privly.Org.phish.org'
+    click_button 'save_whitelist'
+    page.driver.browser.get("http://test.privly.org/test_pages/nonwhitelist.html")
+    assert page.has_xpath?('//iframe')
+
+    # Assert something injected
+    page.driver.browser.get("http://test.privly.org/test_pages/nonwhitelist.html")
+    assert page.has_xpath?('//iframe')
+  end
+
+  def test_changing_content_server
+
+    if not @@privly_extension_active
+      return
+    end
+
+    page.select 'https://dev.privly.org', :from => 'content_server_url'
+    click_button('save_server')
+    page.driver.browser.get(@options_url)
+    assert page.has_content?('dev.privly.org')
+    page.select 'https://privlyalpha.org (recommended)', :from => 'content_server_url'
+    click_button('save_server')
+  end
+
+  def teardown
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+
+end

--- a/test/selenium/specs/tc_new.rb
+++ b/test/selenium/specs/tc_new.rb
@@ -16,7 +16,7 @@ class TestNew < Test::Unit::TestCase
       if to_test[:manifest_dictionary]["action"] == "new" and
         not to_test[:manifest_dictionary]["name"] == "Help" and
         not to_test[:manifest_dictionary]["name"] == "Login"
-        page.driver.browser.get(to_test[:url]); # Re-load the page after we set the server
+        page.driver.browser.get(to_test[:url]) # Re-load the page after we set the server
         login(to_test[:content_server])
         fill_in 'content', :with =>  "Hello WebDriver!"
         click_on ('save')
@@ -49,7 +49,7 @@ class TestNew < Test::Unit::TestCase
       fill_in 'content', :with =>  "Hello WebDriver!"
       Selenium::WebDriver::Support::Select.new(page.driver.browser.find_element(:id, "seconds_until_burn")).select_by(:text, "1 Day")
       find_button("save").click
-      page.driver.browser.find_element(:css, "span.privlyUrl").click
+      page.find(:css,"span.privlyUrl").click
 
       # Open the created content in the "show" endpoint
       click_link("local_address")

--- a/test/selenium/specs/ts_all_specs.rb
+++ b/test/selenium/specs/ts_all_specs.rb
@@ -2,3 +2,4 @@
 require_relative "tc_new"
 require_relative "tc_show"
 require_relative "tc_show_injected"
+require_relative "tc_extension_options"


### PR DESCRIPTION
This pull request adds test coverage for the options page on the Firefox and Chrome extensions. It also has several fixes I uncovered along the way to the testing system, most notably allowing the selenium tests to execute from any directory.

I am going to merge this immediately into the Firefox branch because a forthcoming Firefox PR depends on it. I will open a new PR to master containing these changes.