### PR TITLE
Fix storage test failures

### DIFF
--- a/shared/javascripts/local_storage.js
+++ b/shared/javascripts/local_storage.js
@@ -24,11 +24,12 @@ var ls = {
     }
 
     if ( ls.localStorageDefined ) {
-      return localStorage.setItem(key, value);
+      localStorage.setItem(key, value);
     } else {
       ls.preferences.setCharPref(key, value);
-      return value;
     }
+
+    return value;
   },
 
   /**

--- a/shared/javascripts/local_storage.js
+++ b/shared/javascripts/local_storage.js
@@ -24,7 +24,7 @@ var ls = {
     }
 
     if ( ls.localStorageDefined ) {
-      return localStorage[key] = value;
+      return localStorage.setItem(key, value);
     } else {
       ls.preferences.setCharPref(key, value);
       return value;
@@ -41,11 +41,15 @@ var ls = {
    */
   getItem: function(key) {
     if ( ls.localStorageDefined ) {
+      var value = localStorage.getItem(key);
+      if (value === null){
+        return undefined;
+      }
       try {  // try to parse stored value as JSON
-        var value = JSON.parse(localStorage[key]);
-        return value;
+        var parsed = JSON.parse(value);
+        return parsed;
       } catch(e) { // return original value
-        return localStorage[key];
+        return value;
       }
     } else {
       try {


### PR DESCRIPTION
The tests were failing in firefox because localStorage["key"] is not the same as localStorage.getItem("key").  This fixes that issue.

This also changes the default behavior of localStorage to explicitly return undefined when a key is undefined. By default localStorage returns null when a key is undefined.