### PR TITLE
Removed deprecated spec rendering

### DIFF
--- a/Help/content_server.html.subtemplate
+++ b/Help/content_server.html.subtemplate
@@ -2,11 +2,6 @@
 
 {% block title %}<title>{{name}}</title>{% endblock %}
 
-{% block specs %}
-  <meta name="PrivlySpec"
-   content="../shared/test/parameters.js,../shared/test/extension_integration.js,../shared/test/network_service.js"/>
-{% endblock %}
-
 {% block javascripts %}
 <script type="text/javascript" src="../vendor/jquery.min.js"></script>
 <script type="text/javascript" src="js/help.js"></script>

--- a/Help/new.html.subtemplate
+++ b/Help/new.html.subtemplate
@@ -2,11 +2,6 @@
 
 {% block title %}<title>{{name}}</title>{% endblock %}
 
-{% block specs %}
-  <meta name="PrivlySpec"
-   content="../shared/test/parameters.js,../shared/test/extension_integration.js,../shared/test/network_service.js,../shared/test/local_storage.js"/>
-{% endblock %}
-
 {% block javascripts %}
 <script type="text/javascript" src="../vendor/jquery.min.js"></script>
 <script type="text/javascript" src="js/help.js"></script>

--- a/History/new.html.subtemplate
+++ b/History/new.html.subtemplate
@@ -1,10 +1,5 @@
 {% extends "templates/new.html.template" %}
 
-{% block specs %}
-  <meta name="PrivlySpec" 
-    content="test/new.js,../shared/test/parameters.js,../shared/test/extension_integration.js,../shared/test/network_service.js,../shared/test/local_storage.js"/>
-{% endblock %}
-
 {% block javascripts %}
   <script type="text/javascript" src="../vendor/jquery.min.js">
   </script>

--- a/Login/new.html.subtemplate
+++ b/Login/new.html.subtemplate
@@ -1,9 +1,5 @@
 {% extends "templates/new.html.template" %}
 
-{% block specs %}
-  <meta name="PrivlySpec" content="test/new.js" />
-{% endblock %}
-
 {% block javascripts %}
   <script type="text/javascript" src="../vendor/jquery.min.js"></script>
   <script type="text/javascript" src="js/new.js"></script>

--- a/Message/new.html.subtemplate
+++ b/Message/new.html.subtemplate
@@ -1,10 +1,5 @@
 {% extends "templates/new.html.template" %}
 
-{% block specs %}
-  <meta name="PrivlySpec" 
-  content="../shared/test/privly-web/new.js,test/new.js,test/sjcl.js,test/ZeroBin.js,../shared/test/parameters.js,../shared/test/extension_integration.js,../shared/test/network_service.js,../shared/test/local_storage.js"/>
-{% endblock %}
-
 {% block javascripts %}
   <script type="text/javascript" src="../vendor/jquery.min.js"></script>
   <script type="text/javascript" src="../vendor/jquery.autosize.js"></script>

--- a/Message/show.html.subtemplate
+++ b/Message/show.html.subtemplate
@@ -1,11 +1,6 @@
 {% extends "templates/show.html.template" %}
 
 
-{% block specs %}
-  <meta name="PrivlySpec" content="test/show.js,test/sjcl.js,test/ZeroBin.js,../shared/test/privly-web/show.js,../shared/test/parameters.js,../shared/test/network_service.js,../shared/test/local_storage.js"/>
-{% endblock %}
-
-
 {% block javascripts %}
   <script type="text/javascript" src="../vendor/markdown.js"></script>
   <script type="text/javascript" src="../vendor/jquery.min.js"></script>

--- a/Pages/ChromeFirstRun.html.subtemplate
+++ b/Pages/ChromeFirstRun.html.subtemplate
@@ -1,10 +1,5 @@
 {% extends "templates/new.html.template" %}
 
-{% block specs %}
-  <meta name="PrivlySpec"
-   content="../shared/test/parameters.js,../shared/test/extension_integration.js,../shared/test/network_service.js"/>
-{% endblock %}
-
 {% block javascripts %}
   <script type="text/javascript" src="../vendor/jquery.min.js"></script>
   <script type="text/javascript" src="../shared/javascripts/tooltip.js"></script>

--- a/Pages/ChromeOptions.html.subtemplate
+++ b/Pages/ChromeOptions.html.subtemplate
@@ -1,11 +1,5 @@
 {% extends "templates/new.html.template" %}
 
-{% block specs %}
-  <meta name="PrivlySpec"
-   content="../shared/test/parameters.js,../shared/test/extension_integration.js,
-            ../shared/test/network_service.js,./js/tests/OptionsSpec.js"/>
-{% endblock %}
-
 {% block javascripts %}
   <script type="text/javascript" src="../vendor/jquery.min.js"></script>
   <script type="text/javascript" src="js/options.js"></script>

--- a/PlainPost/new.html.subtemplate
+++ b/PlainPost/new.html.subtemplate
@@ -1,10 +1,5 @@
 {% extends "templates/new.html.template" %}
 
-{% block specs %}
-  <meta name="PrivlySpec"
-   content="../shared/test/privly-web/new.js,test/new.js,../shared/test/parameters.js,../shared/test/extension_integration.js,../shared/test/network_service.js,../shared/test/local_storage.js"/>
-{% endblock %}
-
 {% block javascripts %}
   <script type="text/javascript" src="../vendor/jquery.min.js"></script>
   <script type="text/javascript" src="../vendor/jquery.autosize.js"></script>

--- a/PlainPost/show.html.subtemplate
+++ b/PlainPost/show.html.subtemplate
@@ -1,9 +1,5 @@
 {% extends "templates/show.html.template" %}
 
-{% block specs %}
-  <meta name="PrivlySpec" content="test/show.js,../shared/test/parameters.js,../shared/test/network_service.js,../shared/test/privly-web/show.js,../shared/test/host_page_integration.js,../shared/test/tooltip.j,../shared/test/local_storage.jss"/>
-{% endblock %}
-
 {% block javascripts %}
   <script type="text/javascript" src="../vendor/jquery.min.js"></script>
   <script type="text/javascript" src="../vendor/markdown.js"></script>

--- a/templates/new.html.template
+++ b/templates/new.html.template
@@ -10,8 +10,6 @@
 
     {% block title %}<title> New {{ name }}</title>{% endblock %}
     
-    {% block specs %}{% endblock %}
-    
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     
     <!-- Top Styles -->

--- a/templates/show.html.template
+++ b/templates/show.html.template
@@ -9,9 +9,7 @@
      -->
 
     <title>{{name}}</title>
-    
-    {% block specs %}{% endblock %}
-    
+
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="description" content="This link contains your friend's private content. Click through to read.">
     <meta name="og:description" content="This link contains your friend's private content. Click through to read.">


### PR DESCRIPTION
The Jasmine tests no longer run in user space so the meta directive for privlyspecs is no longer needed.