### PR TITLE
Bump tested versions to nightlies

### DIFF
--- a/test/karma.conf-ci.js
+++ b/test/karma.conf-ci.js
@@ -57,12 +57,12 @@ module.exports = function(config) {
           base: 'SauceLabs',
           browserName: 'chrome',
           platform: 'Windows 7',
-          version: '35'
+          version: 'dev'
         },
     'sl_firefox': {
       base: 'SauceLabs',
       browserName: 'firefox',
-      version: '30'
+      version: 'dev'
     }
   };
 

--- a/test/selenium/run_all.rb
+++ b/test/selenium/run_all.rb
@@ -93,14 +93,16 @@ if platform.start_with? "sauce"
   Sauce.config do |config|
     config['name'] = "Feature Specs"
     config['browserName'] = @browser
+
+    # https://docs.saucelabs.com/reference/platforms-configurator
     if @browser == "firefox"
       @sauce_caps = Selenium::WebDriver::Remote::Capabilities.firefox
-      config['version'] = "34"
-      @sauce_caps.version = "34"
+      config['version'] = "dev"
+      @sauce_caps.version = "dev"
     elsif @browser == "chrome"
       @sauce_caps = Selenium::WebDriver::Remote::Capabilities.chrome
-      config['version'] = "39"
-      @sauce_caps.version = "39"
+      config['version'] = "dev"
+      @sauce_caps.version = "dev"
     end
 
     @sauce_caps.platform = "Windows 7"


### PR DESCRIPTION
This pull request changes the versions we test on SauceLabs to be the most up-to-date browser versions possible for both Chrome and Firefox. The reason I selected these versions is it will give us more warning of impending breaking API changes. Also we don't want to support old versions of browsers because their security vulnerabilities break the extension's threat model.