### PR TITLE
Modify equality operator to strict

### DIFF
--- a/History/js/modal.js
+++ b/History/js/modal.js
@@ -107,7 +107,7 @@ var historyModal = {
 
       //finds the next button with preview_link class and passes its reference.
       var index = $('.preview_link').index(historyModal.eventHandlers.buttonClicked);
-      if(index == $('.preview_link').length - 1){
+      if(index === $('.preview_link').length - 1){
         index = -1; //rolling back to the first message after the last.
       }
       var next = $('.preview_link').slice(index+1).first();


### PR DESCRIPTION
CodeClimate Level 0 style issue suggestion

Expected '===' and instead saw '==' at Line 110