### PR TITLE
Issue #191: Unit tests for SplitImage.

### DIFF
--- a/SplitImage/js/new.js
+++ b/SplitImage/js/new.js
@@ -58,10 +58,10 @@ function save(imageURL) {
  */
 function initializeApplication() {
   
-  // 
+  // Add event listerner on hidden input field
   document.getElementById('files').addEventListener('change', 
     handleFileSelect, false);
-  
+
   // Handle drag and drop
   var dropZone = document.getElementById('drop_zone');
   dropZone.addEventListener('dragover', handleDragOver, false);
@@ -78,4 +78,14 @@ function initializeApplication() {
   callbacks.pendingLogin();
 }
 
-document.addEventListener('DOMContentLoaded', initializeApplication);
+// Initialize the application
+document.addEventListener('DOMContentLoaded',
+  function() {
+
+    // Don't start the script if it is running in a Headless
+    // browser
+    if( document.getElementById("logout_link") ) {
+      initializeApplication();
+    }
+  }
+);

--- a/SplitImage/js/show.js
+++ b/SplitImage/js/show.js
@@ -80,22 +80,30 @@ function encryptBeforeUpdate(evt, callback) {
   state.isInlineEdit = false;
 }
 
-// Make the Tooltip display this App's name.
-privlyTooltip.appName = "SplitImage";
+function initializeApplication() {
+
+  // Make the Tooltip display this App's name.
+  privlyTooltip.appName = "SplitImage";
+
+  var dropZone = document.getElementById('drop_zone');
+  dropZone.addEventListener('dragover', handleDragOver, false);
+  dropZone.addEventListener('drop', handleFileSelect, false);
+  
+  // Start the app
+  callbacks.pendingContent(processResponseContent);
+
+  // Replace the update function so we never send the cleartext server side.
+  callbacks.update = encryptBeforeUpdate;
+}
 
 // Initialize the application
-document.addEventListener('DOMContentLoaded', 
-  function(){
-    
-    // Handle drag and drop on update
-    var dropZone = document.getElementById('drop_zone');
-    dropZone.addEventListener('dragover', handleDragOver, false);
-    dropZone.addEventListener('drop', handleFileSelect, false);
-    
-    // Start the app
-    callbacks.pendingContent(processResponseContent);
+document.addEventListener('DOMContentLoaded',
+  function() {
+
+    // Don't start the script if it is running in a Headless
+    // browser
+    if( document.getElementById("logout_link") ) {
+      initializeApplication();
+    }
   }
 );
-
-// Replace the update function so we never send the cleartext server side.
-callbacks.update = encryptBeforeUpdate;

--- a/SplitImage/test/new.js
+++ b/SplitImage/test/new.js
@@ -3,11 +3,45 @@
  * This spec is managed by the Jasmine testing library.
  **/
  
+
 describe ("SplitImage New Suite", function() {
   
-  it("initializes properly", function() {
-    // pass
-  });
-  
-});
+  var new_fixtures = [
+    '<a class="home_domain">Privly</a>',
+    '<a class="legal_nav">Legal</a>',
+    '<a class="account_url">Account<a/>',
+    '<a id="logout_link">Logout</a>',
+    '<ul><li class="mobile_hide"></li></ul>',
+    '<div id="drop_zone"></div>',
+    '<input type="file" id="files" multiple />',
+    '<button id="save"></button>'
+  ]
 
+  beforeEach(function() {
+    for (var i=0; i<new_fixtures.length; i++) {
+      document.body.innerHTML += new_fixtures[i];
+    }
+  });
+
+  afterEach(function() {
+    document.body.innerHTML = '';
+  });
+
+  it("initializes properly", function() {
+    initializeApplication();
+
+    var domain = privlyNetworkService.contentServerDomain();
+
+    if( privlyNetworkService.platformName() !== "HOSTED" ) {
+
+      // if the app is not hosted, the user should first be directed to the
+      // content_server page of the app bundle.
+      expect($(".home_domain").attr("href")).toBe('../Help/content_server.html');
+    } else {
+
+      // if the application is hosted, the URL should connect to the domain's root
+      expect($(".home_domain").attr("href")).toBe("http://" + window.location.href.split("/")[2]);
+    }
+    expect(domain.split("/")[2]).toBe($(".home_domain").text());
+  });
+});

--- a/SplitImage/test/show.js
+++ b/SplitImage/test/show.js
@@ -1,13 +1,46 @@
 /**
- * @fileOverview tests.js Gives testing code for the show page.
+ * @fileOverview show.js Gives testing code for the show page.
  * This spec is managed by the Jasmine testing library.
  **/
  
-describe ("SplitImaage Show Suite", function() {
-  
-  it("initializes properly", function() {
-    // pass
+describe ("SplitImage Show Suite", function() {
+
+  var show_fixtures = [
+    '<a class="home_domain">Privly</a>',
+    '<a id="logout_link">Logout</a>',
+    '<div id="drop_zone"></div>',
+    '<input type="file" id="files" multiple />',
+    '<button id="update"></button>',
+  ]
+
+  beforeEach(function() {
+    for (var i=0; i<show_fixtures.length; i++) {
+      document.body.innerHTML += show_fixtures[i];
+    }
   });
-  
+
+  afterEach(function() {
+    document.body.innerHTML = '';
+  });
+
+  it("initializes properly", function() {
+
+    initializeApplication();
+
+    var domain = privlyNetworkService.contentServerDomain();
+
+    if( privlyNetworkService.platformName() !== "HOSTED" ) {
+
+      // if the app is not hosted, the user should first be directed to the
+      // content_server page of the app bundle.
+      expect($(".home_domain").attr("href")).toBe('../Help/content_server.html');
+    } else {
+
+      // if the application is hosted, the URL should connect to the domain's root
+      expect($(".home_domain").attr("href")).toBe("http://" + window.location.href.split("/")[2]);
+    }
+    expect(domain.split("/")[2]).toBe($(".home_domain").text());
+  });
+
 });
 

--- a/test/run_each.sh
+++ b/test/run_each.sh
@@ -39,6 +39,8 @@ runTest 'shared/javascripts/privly-web/new.js,PlainPost/js/new.js,PlainPost/test
 runTest 'shared/javascripts/privly-web/show.js,PlainPost/js/show.js,PlainPost/test/show.js'
 runTest 'shared/javascripts/privly-web/new.js,Message/js/base64.js,Message/js/rawdeflate.js,Message/js/rawinflate.js,Message/js/zerobin.js,Message/js/new.js,Message/test/new.js,Message/test/zerobin.js'
 runTest 'shared/javascripts/privly-web/show.js,Message/js/base64.js,Message/js/rawdeflate.js,Message/js/rawinflate.js,Message/js/zerobin.js,Message/js/show.js,Message/test/show.js,Message/test/zerobin.js'
+runTest 'shared/javascripts/privly-web/new.js,SplitImage/js/file_processing.js,SplitImage/js/new.js,SplitImage/test/new.js'
+runTest 'shared/javascripts/privly-web/show.js,Message/js/base64.js,Message/js/rawdeflate.js,Message/js/rawinflate.js,Message/js/zerobin.js,SplitImage/js/file_processing.js,SplitImage/js/show.js,SplitImage/test/show.js'
 
 if [ ! $ISFAIL -eq 0 ]
 then


### PR DESCRIPTION
Unit test for `initializeApplication` of SplitImage. Used fixtures for creating the initial expected state for the tests.

Changes done in the non-testing scripts:
1. Moved `initializeApplication` inside `DOMContentLoaded` event callback for SplitImage/js/new.js.
2. Created `initializeApplication` to take care of all initialization tasks for SplitImage/js/show.js . Also, kept the same inside `DOMContentLoaded` event callback.