### PR TITLE
Update Sub Template for New Help

### DIFF
--- a/Help/new.html.subtemplate
+++ b/Help/new.html.subtemplate
@@ -66,8 +66,8 @@
         <span class="glyphicon glyphicon-eye-open"></span> 
         Indie Hosts Only:
       </strong> 
-      Other applications built on Privly provide privacy only in special 
-      circumstances and should be viewed as "experts only."
+      "These applications provide privacy if you host your own content server. 
+      If you don't know what that means, you should not use these apps."
     </p>
     <div class="col-md-3">
       <form action="../PlainPost/new.html" style="display:inline;">

--- a/Help/new.html.subtemplate
+++ b/Help/new.html.subtemplate
@@ -64,7 +64,7 @@
     <p>
       <strong>
         <span class="glyphicon glyphicon-eye-open"></span> 
-        Experts Only:
+        Indie Hosts Only:
       </strong> 
       Other applications built on Privly provide privacy only in special 
       circumstances and should be viewed as "experts only."
@@ -92,7 +92,7 @@
     <h2>Getting Help</h2>
     <p>The Priv.ly Project is an open source, community-driven
       collection of software. Developers support users on 
-      <a href="http://www.privly.org/content/irc" target="_blank">chat</a> and 
+      <a href="https://www.privly.org/content/irc" target="_blank">chat</a> and 
       on 
       <a href="https://groups.google.com/forum/#!forum/privly" target="_blank">
         email.


### PR DESCRIPTION
As a response to the [Issue #165 ](https://github.com/privly/privly-applications/issues/165)
Replaced the "Experts only" heading with "Indie Hosts only" 

Also replaced the http protocol with https, so as to avoid redirection done by server side and pushing the world towards HTTPS era :smile: 