### PR TITLE
Extract common template to a base template

### DIFF
--- a/templates/base.html.template
+++ b/templates/base.html.template
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+
+    <!--
+      This was likely rendered from the Privly-application templating system
+      See: https://github.com/privly/privly-applications/pull/19
+     -->
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    
+    <link href="../shared/css/common.css" media="screen" rel="stylesheet" type="text/css"/>
+    
+    <script type="text/javascript" src="../shared/javascripts/meta_loader.js"></script>
+    <script type="text/javascript" src="../shared/javascripts/parameters.js"></script>
+    <script type="text/javascript" src="../shared/javascripts/network_service.js"></script>
+    <script type="text/javascript" src="../shared/javascripts/local_storage.js"></script>
+
+    {% block head %}{% endblock %}
+  </head>
+  {% block body %}{% endblock %}
+</html>

--- a/templates/base.html.template
+++ b/templates/base.html.template
@@ -9,9 +9,9 @@
      -->
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    
+
     <link href="../shared/css/common.css" media="screen" rel="stylesheet" type="text/css"/>
-    
+
     <script type="text/javascript" src="../shared/javascripts/meta_loader.js"></script>
     <script type="text/javascript" src="../shared/javascripts/parameters.js"></script>
     <script type="text/javascript" src="../shared/javascripts/network_service.js"></script>

--- a/templates/new.html.template
+++ b/templates/new.html.template
@@ -1,8 +1,8 @@
 {% extends "templates/base.html.template" %}
 {% block head %}
-    
+
     {% block title %}<title> New {{ name }}</title>{% endblock %}
-    
+
     <link class="top" href="../vendor/bootstrap/css/bootstrap.min.css" media="screen" rel="stylesheet"/>
     <link class="top" href="../shared/css/top/top.css" rel="stylesheet"/>
     {% block css %}{% endblock %}
@@ -13,10 +13,10 @@
 {% endblock %}
 {% block body %}
   <body data-privly-exclude="true">
-    
+
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="../vendor/bootstrap/js/bootstrap.min.js"></script>
-    
+
     <!-- Wrap all page content here -->
     <div id="wrap">
       {% include "templates/partials/navigation.html.subtemplate" %}
@@ -52,7 +52,7 @@
             </div>
           </div>
         </div>
-        
+
         {% block pre_form %}{% endblock %}
         <div id="form" style="display:none;">
           <div class="row">
@@ -95,17 +95,17 @@
           </div>
         </div>
       </div><!-- /.container -->
-      
-      
+
+
       <div class="container">
         <div class="row">
           {% block app_info %}
           {% endblock %}
         </div><!-- /.row -->
       </div><!-- /.container -->
-      
+
     </div><!-- /.wrap -->
-    
+
     <div id="footer">
       <div class="container">
         <p class="text-muted credit">

--- a/templates/new.html.template
+++ b/templates/new.html.template
@@ -1,44 +1,17 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-
-    <!--
-      This was likely rendered from the Privly-application templating system
-      See: https://github.com/privly/privly-applications/pull/19
-     -->
-
+{% extends "templates/base.html.template" %}
+{% block head %}
+    
     {% block title %}<title> New {{ name }}</title>{% endblock %}
     
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    
-    <!-- Top Styles -->
-    <link class="top" href="../vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen"/>
+    <link class="top" href="../vendor/bootstrap/css/bootstrap.min.css" media="screen" rel="stylesheet"/>
     <link class="top" href="../shared/css/top/top.css" rel="stylesheet"/>
-    
-    <!-- Common Styles -->
-    <link href="../shared/css/common.css" media="screen" rel="stylesheet"
-     type="text/css"/>
-    <link href="../shared/css/tooltip.css" media="screen" rel="stylesheet"
-     type="text/css"/>
-    
     {% block css %}{% endblock %}
-    
-    <script type="text/javascript" src="../shared/javascripts/meta_loader.js">
-    </script>
-    <script type="text/javascript" src="../shared/javascripts/parameters.js">
-    </script>
-    <script type="text/javascript" src="../shared/javascripts/network_service.js">
-    </script>
-    <script type="text/javascript" src="../shared/javascripts/extension_integration.js">
-    </script>
-    <script type="text/javascript" src="../shared/javascripts/local_storage.js">
-    </script>
-     
-    {% block javascripts %}{% endblock %}
-     
-  </head>
 
+    <script type="text/javascript" src="../shared/javascripts/extension_integration.js"></script>
+    {% block javascripts %}{% endblock %}
+
+{% endblock %}
+{% block body %}
   <body data-privly-exclude="true">
     
     <!-- Include all compiled plugins (below), or include individual files as needed -->
@@ -155,4 +128,4 @@
       </div>
     </div>
   </body>
-</html>
+{% endblock %}

--- a/templates/show.html.template
+++ b/templates/show.html.template
@@ -6,13 +6,13 @@
     <meta name="description" content="This link contains your friend's private content. Click through to read.">
     <meta name="og:description" content="This link contains your friend's private content. Click through to read.">
     <meta name="twitter:description" content="This link contains your friend's private content. Click through to read.">
-    
+
     <link href="../shared/css/tooltip.css" media="screen" rel="stylesheet" type="text/css"/>
-    
+
     <script type="text/javascript" src="../shared/javascripts/host_page_integration.js"></script>
     <script type="text/javascript" src="../shared/javascripts/tooltip.js"></script>
     {% block javascripts %}{% endblock %}
-    
+
     <!-- Top Styles, will be added by JS if not viewed in iframe -->
     <meta name="PrivlyTopCSS" content="../vendor/bootstrap/css/bootstrap.min.css;../shared/css/top/top.css"/>
     <!-- Injected Styles, will be added by JS if viewed in iframe -->
@@ -21,14 +21,14 @@
 {% endblock %}
 {% block body %}
   <body data-privly-exclude="true">
-    
+
     <script src="../vendor/bootstrap/js/bootstrap.min.js"></script>
-    
+
     <div id="wrap"><!-- for bootstrap footer -->
       <div id="privlyHeightWrapper">
-        
+
         {% include "templates/partials/navigation.html.subtemplate" %}
-        
+
         <div class="container">
           {% block main %}
             <div class="row">

--- a/templates/show.html.template
+++ b/templates/show.html.template
@@ -1,46 +1,25 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-
-    <!--
-      This was likely rendered from the Privly-application templating system
-      See: https://github.com/privly/privly-applications/pull/19
-     -->
+{% extends "templates/base.html.template" %}
+{% block head %}
 
     <title>{{name}}</title>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="description" content="This link contains your friend's private content. Click through to read.">
     <meta name="og:description" content="This link contains your friend's private content. Click through to read.">
     <meta name="twitter:description" content="This link contains your friend's private content. Click through to read.">
     
-    <!-- Common Styles -->
-    <link href="../shared/css/common.css" media="screen" rel="stylesheet"
-     type="text/css"/>
-    <link href="../shared/css/tooltip.css" media="screen" rel="stylesheet"
-     type="text/css"/>
+    <link href="../shared/css/tooltip.css" media="screen" rel="stylesheet" type="text/css"/>
     
-    <!-- Shared JavaScripts -->  
-    <script type="text/javascript" src="../shared/javascripts/meta_loader.js"></script>
-    <script type="text/javascript" src="../shared/javascripts/parameters.js"></script>
     <script type="text/javascript" src="../shared/javascripts/host_page_integration.js"></script>
-    <script type="text/javascript" src="../shared/javascripts/network_service.js"></script>
     <script type="text/javascript" src="../shared/javascripts/tooltip.js"></script>
-    <script type="text/javascript" src="../shared/javascripts/local_storage.js">
-    </script>
-    
-    <!-- Application Specific JavaScripts -->
     {% block javascripts %}{% endblock %}
     
     <!-- Top Styles, will be added by JS if not viewed in iframe -->
     <meta name="PrivlyTopCSS" content="../vendor/bootstrap/css/bootstrap.min.css;../shared/css/top/top.css"/>
-    
     <!-- Injected Styles, will be added by JS if viewed in iframe -->
-    <meta name="PrivlyInjectedCSS"
-     content="../shared/css/injected/injected.css"/>
-     
-  </head>
+    <meta name="PrivlyInjectedCSS" content="../shared/css/injected/injected.css"/>
+
+{% endblock %}
+{% block body %}
   <body data-privly-exclude="true">
     
     <script src="../vendor/bootstrap/js/bootstrap.min.js"></script>
@@ -167,4 +146,4 @@
       </div>
     </div>
   </body>
-</html>
+{% endblock %}


### PR DESCRIPTION
This allows developers to write a page other than 'show' or 'new' but uses privly fundamental libraries:

```twig
{% extends "templates/base.html.template" %}
```

More specifically, I want to write a callback page of login in seemless-posting. The current code repo only allows redirecting to URLs when login (not calling back JavaScript functions) and I don't want to modify too much code.