### PR TITLE
Testing refactor

### DIFF
--- a/Pages/ChromeOptions.html.subtemplate
+++ b/Pages/ChromeOptions.html.subtemplate
@@ -67,7 +67,7 @@
         <span class="glyphicon glyphicon-remove remove_whitelist" ></span>
       </div>
     </div>
-    <div id="invalid_domain">You have invalid domains that were not saved</div>
+    <div id="invalid_domain">Domains are not saved until all are valid</div>
     <div id="status"></div>
     <span id="add_more_urls">
       <span class="glyphicon glyphicon-plus-sign"></span> Add more 

--- a/Pages/js/options.js
+++ b/Pages/js/options.js
@@ -82,7 +82,11 @@ function isValidDomain(domain) {
 
   var parts = domain.split(".");
   var valid_parts_count = 0;
-    
+
+  if( parts.length < 2 ) {
+    return false;
+  }
+
   //iterate over domains, split by .
   for (var j = 0; j < parts.length; j++) {
     switch (j){
@@ -151,17 +155,18 @@ function saveWhitelist() {
     }
   }
   if (invalid_domains) {
-      invalid_domain.className = 'show';
-  }
-  ls.setItem("user_whitelist_json", JSON.stringify(domains));
-  ls.setItem("user_whitelist_regexp", domain_regexp);
+    invalid_domain.className = 'show';
+  } else {
+    ls.setItem("user_whitelist_json", JSON.stringify(domains));
+    ls.setItem("user_whitelist_regexp", domain_regexp);
 
-  // Update status to let user know options were saved.
-  var status = document.getElementById("status");
-  status.innerHTML = "Options Saved.";
-  setTimeout(function() {
-    status.innerHTML = "";
-  }, 750);
+    // Update status to let user know options were saved.
+    var status = document.getElementById("status");
+    status.innerHTML = "Options Saved.";
+    setTimeout(function() {
+      status.innerHTML = "";
+    }, 1000);
+  }
 }
 
 
@@ -312,7 +317,7 @@ function listeners(){
   // Click on body used to tackle dynamically created remove whitelist url buttons
   document.querySelector('body').addEventListener('click', removeWhitelistUrl);
 
-  document.querySelector('body').addEventListener('focusout', onFocusOut);
+  document.querySelector('body').addEventListener('input', inputEvent);
 }
 
 /**
@@ -446,11 +451,15 @@ function removeWhitelistUrl (event) {
   }
 }
 
-function onFocusOut (event) {
-  var target = event.target;
-  if (target.className.indexOf('whitelist_url') < 0) 
-    return;
-  saveWhitelist()
+/**
+ * Saves the whitelist if the whitelist changed.
+ * @param {event} ev The input event.
+ */
+function inputEvent (ev) {
+  var target = ev.target;
+  if (target.classList.contains('whitelist_url')) {
+    saveWhitelist();
+  }
 }
 
 // Initialize the application

--- a/test/selenium/configurations.rb
+++ b/test/selenium/configurations.rb
@@ -16,12 +16,15 @@ Capybara.run_server = false
 
 # This is the common config for running tests from the
 # web scripting environment
-def common_configuration_for_web
+def common_configuration_for_web(args)
+
+  # Assign the privly-applications repository path
+  content_server = args[:content_server]
+  @@privly_applications_folder_path = content_server + "/apps/"
+
   Capybara.register_driver :web_browser do |app|
    Capybara::Selenium::Driver.new(app, :browser => @browser.to_sym)
   end
-  @@privly_applications_folder_path = "http://localhost:3000/apps/"
-  content_server = "http://localhost:3000"
   Capybara.default_driver = :web_browser
   Capybara.current_driver = :web_browser
 end
@@ -54,7 +57,12 @@ end
 
 # This is the common config for running tests from the
 # web scripting environment on SauceLabs
-def common_configuration_for_sauce_web
+def common_configuration_for_sauce_web(args)
+
+  # Assign the applications path
+  content_server = args[:content_server]
+  @@privly_applications_folder_path = content_server + "/apps/"
+
   Capybara.register_driver :sauce_web do |app|
    Capybara::Selenium::Driver.new(
      app,
@@ -111,25 +119,25 @@ def common_configuration_for_sauce
   end
 end
 
-def configure_for_firefox_web
-  common_configuration_for_web
+def configure_for_firefox_web(args)
+  common_configuration_for_web(args)
 end
 
-def configure_for_chrome_web
-  common_configuration_for_web
+def configure_for_chrome_web(args)
+  common_configuration_for_web(args)
 end
 
-def configure_for_sauce_firefox_web
+def configure_for_sauce_firefox_web(args)
   common_configuration_for_sauce
-  common_configuration_for_sauce_web
+  common_configuration_for_sauce_web(args)
 end
 
-def configure_for_sauce_chrome_web
+def configure_for_sauce_chrome_web(args)
   common_configuration_for_sauce
-  common_configuration_for_sauce_web
+  common_configuration_for_sauce_web(args)
 end
 
-def configure_for_sauce_firefox_extension
+def configure_for_sauce_firefox_extension(args)
   common_configuration_for_sauce
   common_configuration_for_firefox_extension
   @sauce_caps.firefox_profile = @profile
@@ -145,7 +153,7 @@ def configure_for_sauce_firefox_extension
   Capybara.default_driver = :sauce_firefox_extension
 end
 
-def configure_for_sauce_chrome_extension
+def configure_for_sauce_chrome_extension(args)
 
   common_configuration_for_sauce
 
@@ -176,7 +184,7 @@ def configure_for_sauce_chrome_extension
 
 end
 
-def configure_for_firefox_extension
+def configure_for_firefox_extension(args)
   common_configuration_for_firefox_extension
   Capybara.register_driver :firefox_extension do |app|
     Capybara::Selenium::Driver.new(app, :browser => :firefox, :profile => @profile)
@@ -185,7 +193,7 @@ def configure_for_firefox_extension
   Capybara.default_driver = :firefox_extension
 end
 
-def configure_for_chrome_extension
+def configure_for_chrome_extension(args)
   # This currently references the relative path to the URL
   caps = Selenium::WebDriver::Remote::Capabilities.chrome(
     "chromeOptions" => {

--- a/test/selenium/configurations.rb
+++ b/test/selenium/configurations.rb
@@ -42,10 +42,14 @@ end
 
 # This is the common config for running tests from the
 # Chrome scripting environment
-def common_configuration_for_chrome_extension
-  # Assign the path to find the applications in the extension
-  Capybara.app_host = "chrome-extension://gipdbddcenpbjpmjblgmogkeblhoaejd"
-  @@privly_applications_folder_path = Capybara.app_host + "/privly-applications/"
+def assign_chrome_extension_path
+
+  # The chrome URL can change periodically so this test grabs the
+  # URL from the first run page. It also fixes the path in the
+  # CRUD tests since this test doesn't run until all the
+  # initialization is complete
+  require_relative "tc_chrome_helper"
+  @@privly_applications_folder_path = ""
 end
 
 # This is the common config for running tests from the
@@ -144,7 +148,6 @@ end
 def configure_for_sauce_chrome_extension
 
   common_configuration_for_sauce
-  common_configure_for_chrome_extension
 
   # Package the extension
   system("../../../package/travis.sh")
@@ -168,6 +171,9 @@ def configure_for_sauce_chrome_extension
   end
   Capybara.current_driver = :sauce_chrome_extension
   Capybara.default_driver = :sauce_chrome_extension
+
+  assign_chrome_extension_path
+
 end
 
 def configure_for_firefox_extension
@@ -180,7 +186,6 @@ def configure_for_firefox_extension
 end
 
 def configure_for_chrome_extension
-  common_configuration_for_chrome_extension
   # This currently references the relative path to the URL
   caps = Selenium::WebDriver::Remote::Capabilities.chrome(
     "chromeOptions" => {
@@ -194,4 +199,7 @@ def configure_for_chrome_extension
   end
   Capybara.current_driver = :chrome_extension
   Capybara.default_driver = :chrome_extension
+
+  assign_chrome_extension_path
+
 end

--- a/test/selenium/configurations.rb
+++ b/test/selenium/configurations.rb
@@ -1,0 +1,197 @@
+# This file contains all the boilerplate code to enable integration with many
+# different browser and scripting contexts.
+
+require 'selenium-webdriver' # Connecting to the browsers
+require 'capybara' # Manages Selenium
+require 'capybara/dsl' # Syntax for interacting with Selenium
+require 'test/unit' # Provides syntax for expectation statements
+
+# Sets the amount of time tests will wait for
+# asynchronous events to happen. Increasing this
+# parameter is a good way to debug why your tests
+# may be failing
+Capybara.default_wait_time = 15
+
+Capybara.run_server = false
+
+# This is the common config for running tests from the
+# web scripting environment
+def common_configuration_for_web
+  Capybara.register_driver :web_browser do |app|
+   Capybara::Selenium::Driver.new(app, :browser => @browser.to_sym)
+  end
+  @@privly_applications_folder_path = "http://localhost:3000/apps/"
+  content_server = "http://localhost:3000"
+  Capybara.default_driver = :web_browser
+  Capybara.current_driver = :web_browser
+end
+
+# This is the common config for running tests from the
+# Firefox scripting environment
+def common_configuration_for_firefox_extension
+  # Assign the path to find the applications in the extension
+  Capybara.app_host = "chrome://privly"
+  @@privly_applications_folder_path = Capybara.app_host + "/content/privly-applications/"
+  puts "Packaging the Firefox Extension"
+  system( "cd ../../../../../ && pwd && ./package.sh && cd chrome/content/privly-applications/test/selenium" )
+
+  # Load the Firefox driver with the extension installed
+  @profile = Selenium::WebDriver::Firefox::Profile.new
+  @profile.add_extension("../../../../../PrivlyFirefoxExtension.xpi")
+end
+
+# This is the common config for running tests from the
+# Chrome scripting environment
+def common_configuration_for_chrome_extension
+  # Assign the path to find the applications in the extension
+  Capybara.app_host = "chrome-extension://gipdbddcenpbjpmjblgmogkeblhoaejd"
+  @@privly_applications_folder_path = Capybara.app_host + "/privly-applications/"
+end
+
+# This is the common config for running tests from the
+# web scripting environment on SauceLabs
+def common_configuration_for_sauce_web
+  Capybara.register_driver :sauce_web do |app|
+   Capybara::Selenium::Driver.new(
+     app,
+     :browser => :remote,
+     :url => @sauce_url,
+     :desired_capabilities => @sauce_caps
+    )
+  end
+  Capybara.default_driver = :sauce_web
+  Capybara.current_driver = :sauce_web
+end
+
+# This is the common config for running tests on SauceLabs.
+# Requires Sauce Connect
+# https://docs.saucelabs.com/reference/sauce-connect/
+def common_configuration_for_sauce
+  require 'sauce'
+  require 'sauce/capybara'
+  Sauce.config do |config|
+    config['name'] = "Feature Specs"
+    config['browserName'] = @browser
+
+    # https://docs.saucelabs.com/reference/platforms-configurator
+    if @browser == "firefox"
+      @sauce_caps = Selenium::WebDriver::Remote::Capabilities.firefox
+      config['version'] = "dev"
+      @sauce_caps.version = "dev"
+    elsif @browser == "chrome"
+      @sauce_caps = Selenium::WebDriver::Remote::Capabilities.chrome
+      config['version'] = "dev"
+      @sauce_caps.version = "dev"
+    end
+
+    @sauce_caps.platform = "Windows 7"
+    @sauce_caps[:name] = "Priv.ly Project Integration Tests"
+    if ENV['SAUCE_URL'] == nil or ENV['SAUCE_URL'] == ""
+      puts "Before you can test on Sauce you need to set an environmental variable containing your Sauce URL"
+      exit 1
+    end
+
+    # You can also hard code the URL here, but remember it contains your credentials...
+    @sauce_url = ENV['SAUCE_URL']
+
+    # Support TravisCI if that is where this is running
+    if ENV['TRAVIS_JOB_NUMBER']
+      @sauce_caps["tunnel-identifier"] = ENV['TRAVIS_JOB_NUMBER']
+    end
+
+    # Give the webserver time to boot when running on TravisCI
+    if ENV['TRAVIS_LAUNCHES_SAUCE_CONNECT']
+      puts "sleeping for 5 seconds"
+      sleep 5
+    end
+  end
+end
+
+def configure_for_firefox_web
+  common_configuration_for_web
+end
+
+def configure_for_chrome_web
+  common_configuration_for_web
+end
+
+def configure_for_sauce_firefox_web
+  common_configuration_for_sauce
+  common_configuration_for_sauce_web
+end
+
+def configure_for_sauce_chrome_web
+  common_configuration_for_sauce
+  common_configuration_for_sauce_web
+end
+
+def configure_for_sauce_firefox_extension
+  common_configuration_for_sauce
+  common_configuration_for_firefox_extension
+  @sauce_caps.firefox_profile = @profile
+  Capybara.register_driver :sauce_firefox_extension do |app|
+    Capybara::Selenium::Driver.new(
+      app,
+      :browser => :remote,
+      :url => @sauce_url,
+      :desired_capabilities => @sauce_caps
+    )
+  end
+  Capybara.current_driver = :sauce_firefox_extension
+  Capybara.default_driver = :sauce_firefox_extension
+end
+
+def configure_for_sauce_chrome_extension
+
+  common_configuration_for_sauce
+  common_configure_for_chrome_extension
+
+  # Package the extension
+  system("../../../package/travis.sh")
+
+  # extensions cannot be read as text
+  # Base64.strict_encode64 File.read(crx_path)
+  extension = Base64.strict_encode64 File.binread("../../../PrivlyChromeExtension.crx")
+
+  @sauce_caps["chromeOptions"] = {
+    "args" => [ "--disable-web-security" ],
+    "extensions" => [extension]
+  }
+
+  Capybara.register_driver :sauce_chrome_extension do |app|
+    Capybara::Selenium::Driver.new(
+      app,
+      :browser => :remote,
+      :url => @sauce_url,
+      :desired_capabilities => @sauce_caps
+    )
+  end
+  Capybara.current_driver = :sauce_chrome_extension
+  Capybara.default_driver = :sauce_chrome_extension
+end
+
+def configure_for_firefox_extension
+  common_configuration_for_firefox_extension
+  Capybara.register_driver :firefox_extension do |app|
+    Capybara::Selenium::Driver.new(app, :browser => :firefox, :profile => @profile)
+  end
+  Capybara.current_driver = :firefox_extension
+  Capybara.default_driver = :firefox_extension
+end
+
+def configure_for_chrome_extension
+  common_configuration_for_chrome_extension
+  # This currently references the relative path to the URL
+  caps = Selenium::WebDriver::Remote::Capabilities.chrome(
+    "chromeOptions" => {
+      "args" => [ "--disable-web-security", "load-extension=../../.." ]
+      }
+  )
+
+  Capybara.register_driver :chrome_extension do |app|
+    Capybara::Selenium::Driver.new(app, :browser => :chrome,
+      :desired_capabilities => caps)
+  end
+  Capybara.current_driver = :chrome_extension
+  Capybara.default_driver = :chrome_extension
+end

--- a/test/selenium/run_all.rb
+++ b/test/selenium/run_all.rb
@@ -2,25 +2,17 @@
 # See README.md for details.
 #
 # Run all the specs that are defined in the all_specs.rb
-# file. This script defaults to testing the applications on
-# Firefox without the extension (web). You can specify
-# an extension platform by passing in the associated
-# browser name. You can also set the content server
-# if you are not testing the web platform by passing
-# a domain.
-# Finally, you can limit the tests to particular release statuses
-# by passing another option.
+# file. For a listing of the options, you should run
+# `ruby run_all.rb` without specifying any parameters.
 #
 require 'optparse' # Options parsing
-require 'selenium-webdriver' # Connecting to the browsers
 require 'json' # Crawling the manifest files to decide what to test
-require 'capybara' # Manages Selenium
-require 'capybara/dsl' # Syntax for interacting with Selenium
-require 'test/unit' # Provides syntax for expectation statements
+require_relative "configurations" # The platforms we may test
 
 # Change the directory to this script's directory
 Dir.chdir File.expand_path(File.dirname(__FILE__))
 
+# Specify the required options
 args = {}
 optsHelp = ""
 OptionParser.new do |opts|
@@ -31,6 +23,8 @@ OptionParser.new do |opts|
   optsHelp = opts.help
 end.parse!
 
+puts "You passed the arguments: #{args}"
+
 # Exit if three arguments were not supplied
 if not args.length == 3
   puts "\nYou must specify all three arguments\n\n"
@@ -38,29 +32,60 @@ if not args.length == 3
   exit 1
 end
 
-puts "You passed the arguments: #{args}"
+# Build the data structure used by some specs to determine what to test
+def initialize_CRUD_tests(args)
 
-# Defaults
-platform = "firefox_web" # Assume testing the web version unless otherwise noted
-@@privly_extension_active = false # The apps are not in an extension env
-@@privly_applications_folder_path = "http://localhost:3000/apps/"
-release_status = "deprecated" # Include deprecated apps by default
-Capybara.run_server = false
-Capybara.app_host = 'http://localhost:3000'
-content_server = "http://localhost:3000"
-Capybara.default_wait_time = 15
+  if args[:content_server]
+    content_server = args[:content_server]
+  end
 
-# This global data structure provides a test set that each of the
-# specs can use to guarantee behavior across apps. The components
-# give the URL of the application to be opened in the browser,
-# the content_server that the application is expected to be associated
-# with (default is the same as the domain of the URL), and the dictionary
-# that is passed to the template files.
-@@privly_test_set = [
-  # url,
-  # content_server,
-  # manifest_dictionary
-]
+  if args[:release_status]
+    release_status = args[:release_status]
+  end
+
+  # This global data structure provides a test set that each of the
+  # specs can use to guarantee behavior across apps. The components
+  # give the URL of the application to be opened in the browser,
+  # the content_server that the application is expected to be associated
+  # with (default is the same as the domain of the URL), and the dictionary
+  # that is passed to the template files.
+  @@privly_test_set = [
+    # url,
+    # content_server,
+    # manifest_dictionary
+  ]
+
+  manifest_files = Dir["../../*/manifest.json"]
+  manifest_files.each do |manifest_file|
+    json = JSON.load(File.new(manifest_file))
+    json.each do |app_manifest|
+
+      outfile_path = app_manifest["outfile_path"]
+      if app_manifest["platforms"] and
+        not app_manifest["platforms"].include?(@browser)
+        puts "Skipping due to target platform: " + outfile_path
+        next
+      end
+
+      release_titles = ["redirect", "experimental", "deprecated", "alpha", "beta", "release"]
+      unless release_titles.index(app_manifest["release_status"]) >=
+        release_titles.index(release_status)
+        puts "Skipping due to release status: " + outfile_path
+        next
+      end
+
+      # Pages to be tested
+      page_url = @@privly_applications_folder_path+outfile_path
+
+      @@privly_test_set.push({
+          :url => page_url,
+          :content_server => content_server,
+          :manifest_dictionary => app_manifest["subtemplate_dict"]
+      })
+
+    end
+  end
+end
 
 # Intialize for the platform we are testing
 #
@@ -81,227 +106,67 @@ if args[:platform]
   platform = args[:platform]
 end
 
+# Global variable indicating whether the extension
+# is installed
 @@privly_extension_active = platform.include?("extension")
 
-# Setup the functionality common to all Sauce testing
-# Requires Sauce Connect
-# https://docs.saucelabs.com/reference/sauce-connect/
-if platform.start_with? "sauce"
-  require 'sauce'
-  require 'sauce/capybara'
-  @browser = platform.split("_")[1]
-  Sauce.config do |config|
-    config['name'] = "Feature Specs"
-    config['browserName'] = @browser
+# Assign the name of the browser controlled by Selenium
+if platform.include? "chrome"
+  @browser = "chrome"
+elsif platform.include? "firefox"
+  @browser = "firefox"
+elsif platform.include? "safari"
+  @browser = "safari"
+elsif platform.include? "opera"
+  @browser = "opera"
+elsif platform.include? "ie"
+  @browser = "ie"
+end
 
-    # https://docs.saucelabs.com/reference/platforms-configurator
-    if @browser == "firefox"
-      @sauce_caps = Selenium::WebDriver::Remote::Capabilities.firefox
-      config['version'] = "dev"
-      @sauce_caps.version = "dev"
-    elsif @browser == "chrome"
-      @sauce_caps = Selenium::WebDriver::Remote::Capabilities.chrome
-      config['version'] = "dev"
-      @sauce_caps.version = "dev"
-    end
-
-    @sauce_caps.platform = "Windows 7"
-    @sauce_caps[:name] = "Priv.ly Project Integration Tests"
-    if ENV['SAUCE_URL'] == nil or ENV['SAUCE_URL'] == ""
-      puts "Before you can test on Sauce you need to set an environmental variable containing your Sauce URL"
-      exit 1
-    end
-
-    # You can also hard code the URL here, but remember it contains your credentials...
-    @sauce_url = ENV['SAUCE_URL']
-
-    # Support TravisCI if that is where this is running
-    if ENV['TRAVIS_JOB_NUMBER']
-      @sauce_caps["tunnel-identifier"] = ENV['TRAVIS_JOB_NUMBER']
-    end
-
-    # Give the webserver time to boot when running on TravisCI
-    if ENV['TRAVIS_LAUNCHES_SAUCE_CONNECT']
-      puts "sleeping for 5 seconds"
-      sleep 5
-    end
+# Confirms that the user is running the tests
+# within the proper context
+def sanity_check(expected_string)
+  unless `pwd`.include? expected_string
+    puts "You are testing: " + expected_string
+    puts "but we did not find this string in the code's path."
+    puts "Thus, we are refusing to run any tests."
+    puts "Comment out the sanity check or rename a folder in your path."
+    exit 1
   end
+end
+
+# Configure for the current platform
+if platform == "sauce_firefox_web"
+  sanity_check "privly-web"
+  configure_for_sauce_firefox_web
+elsif platform == "sauce_chrome_web"
+  sanity_check "privly-web"
+  configure_for_sauce_chrome_web
+elsif platform == "firefox_web"
+  sanity_check "privly-web"
+  configure_for_firefox_web
+elsif platform == "chrome_web"
+  sanity_check "privly-web"
+  configure_for_chrome_web
+elsif platform == "firefox_extension"
+  sanity_check "privly-firefox"
+  configure_for_firefox_extension
+elsif platform == "sauce_firefox_extension"
+  sanity_check "privly-firefox"
+  configure_for_sauce_firefox_extension
+elsif platform == "chrome_extension"
+  sanity_check "privly-chrome"
+  configure_for_chrome_extension
+elsif platform == "sauce_chrome_extension"
+  sanity_check "privly-chrome"
+  configure_for_sauce_chrome_extension
 else
-  @browser = platform.split("_")[0]
-end
-
-if platform == "sauce_firefox_web" or platform == "sauce_chrome_web"
-  Capybara.register_driver :sauce_web do |app|
-   Capybara::Selenium::Driver.new(
-     app,
-     :browser => :remote,
-     :url => @sauce_url,
-     :desired_capabilities => @sauce_caps
-    )
-  end
-  Capybara.default_driver = :sauce_web
-  Capybara.current_driver = :sauce_web
-end
-
-if platform == "firefox_web" or platform == "chrome_web"
-  Capybara.register_driver :web_browser do |app|
-   Capybara::Selenium::Driver.new(app, :browser => @browser.to_sym)
-  end
-  @@privly_applications_folder_path = "http://localhost:3000/apps/"
-  content_server = "http://localhost:3000"
-  Capybara.default_driver = :web_browser
-  Capybara.current_driver = :web_browser
-end
-
-# Package and add the Firefox extension as necessary
-if platform.include? "firefox_extension"
-
-  if `pwd`.include? "privly-chrome"
-    puts "\nCannot test the firefox extension from within the chrome extension\n\n"
-    exit 1
-  end
-
-  # Assign the path to find the applications in the extension
-  Capybara.app_host = "chrome://privly"
-  @@privly_applications_folder_path = Capybara.app_host + "/content/privly-applications/"
-  puts "Packaging the Firefox Extension"
-  system( "cd ../../../../../ && pwd && ./package.sh && cd chrome/content/privly-applications/test/selenium" )
-
-  # Load the Firefox driver with the extension installed
-  @profile = Selenium::WebDriver::Firefox::Profile.new
-  @profile.add_extension("../../../../../PrivlyFirefoxExtension.xpi")
-end
-
-if platform == "firefox_extension"
-  Capybara.register_driver :firefox_extension do |app|
-    Capybara::Selenium::Driver.new(app, :browser => :firefox, :profile => @profile)
-  end
-  Capybara.current_driver = :firefox_extension
-  Capybara.default_driver = :firefox_extension
-
-  # Assign the content server to the remote server
-  content_server = "https://dev.privly.org"
-end
-
-if platform == "sauce_firefox_extension"
-  @sauce_caps.firefox_profile = @profile
-  Capybara.register_driver :sauce_firefox_extension do |app|
-    Capybara::Selenium::Driver.new(
-      app,
-      :browser => :remote,
-      :url => @sauce_url,
-      :desired_capabilities => @sauce_caps
-    )
-  end
-  Capybara.current_driver = :sauce_firefox_extension
-  Capybara.default_driver = :sauce_firefox_extension
-end
-
-# requires ChromeDriver
-# Mac: brew install chromedriver
-if platform == "chrome_extension"
-
-  # Assign the path to find the applications in the extension
-  Capybara.app_host = "chrome-extension://gipdbddcenpbjpmjblgmogkeblhoaejd"
-  @@privly_applications_folder_path = Capybara.app_host + "/privly-applications/"
-
-  # This currently references the relative path to the URL
-  caps = Selenium::WebDriver::Remote::Capabilities.chrome(
-    "chromeOptions" => {
-      "args" => [ "--disable-web-security", "load-extension=../../.." ]
-      }
-  )
-
-  Capybara.register_driver :chrome_extension do |app|
-    Capybara::Selenium::Driver.new(app, :browser => :chrome,
-      :desired_capabilities => caps)
-  end
-  Capybara.current_driver = :chrome_extension
-  Capybara.default_driver = :chrome_extension
-
-  # Assign the content server to the remote server
-  content_server = "https://dev.privly.org"
-end
-
-if platform == "sauce_chrome_extension"
-
-  if `pwd`.include? "privly-firefox"
-    puts "\nCannot test the chrome extension from within the firefox extension\n\n"
-    exit 1
-  end
-
-  # Package the extension
-  system("../../../package/travis.sh")
-
-  # extensions cannot be read as text
-  # Base64.strict_encode64 File.read(crx_path)
-  extension = Base64.strict_encode64 File.binread("../../../PrivlyChromeExtension.crx")
-
-  @sauce_caps["chromeOptions"] = {
-    "args" => [ "--disable-web-security" ],
-    "extensions" => [extension]
-  }
-
-  # Assign the path to find the applications in the extension
-  Capybara.app_host = "chrome-extension://gbgechigghkleokfnpebmlfldpbloelf"
-  @@privly_applications_folder_path = Capybara.app_host + "/privly-applications/"
-
-  Capybara.register_driver :sauce_chrome_extension do |app|
-    Capybara::Selenium::Driver.new(
-      app,
-      :browser => :remote,
-      :url => @sauce_url,
-      :desired_capabilities => @sauce_caps
-    )
-  end
-  Capybara.current_driver = :sauce_chrome_extension
-  Capybara.default_driver = :sauce_chrome_extension
-end
-
-# Platforms that are not currently implemented
-if platform == "safari" or platform == "ie"
-  puts "This platform is not integrated into testing"
+  puts "The platform you selected was not recognized or is not supported"
+  puts "Note that Safari and Internet Explorer are integrated"
   exit 1
 end
 
-if args[:content_server]
-  content_server = args[:content_server]
-end
+initialize_CRUD_tests(args)
 
-if args[:release_status]
-  release_status = args[:release_status]
-end
-
-# Build the data structure used by some specs to determine what to test
-manifest_files = Dir["../../*/manifest.json"]
-manifest_files.each do |manifest_file|
-  json = JSON.load(File.new(manifest_file))
-  json.each do |app_manifest|
-
-    outfile_path = app_manifest["outfile_path"]
-    if app_manifest["platforms"] and
-      not app_manifest["platforms"].include?(@browser)
-      puts "Skipping due to target platform: " + outfile_path
-      next
-    end
-
-    release_titles = ["redirect", "experimental", "deprecated", "alpha", "beta", "release"]
-    unless release_titles.index(app_manifest["release_status"]) >= 
-      release_titles.index(release_status)
-      puts "Skipping due to release status: " + outfile_path
-      next
-    end
-
-    # Pages to be tested
-    page_url = @@privly_applications_folder_path+outfile_path
-    
-    @@privly_test_set.push({
-        :url => page_url, 
-        :content_server => content_server, 
-        :manifest_dictionary => app_manifest["subtemplate_dict"]
-    })
-    
-  end
-end
-
+# Run all the tests
 require_relative "specs/ts_all_specs"

--- a/test/selenium/run_all.rb
+++ b/test/selenium/run_all.rb
@@ -138,28 +138,28 @@ end
 # Configure for the current platform
 if platform == "sauce_firefox_web"
   sanity_check "privly-web"
-  configure_for_sauce_firefox_web
+  configure_for_sauce_firefox_web(args)
 elsif platform == "sauce_chrome_web"
   sanity_check "privly-web"
-  configure_for_sauce_chrome_web
+  configure_for_sauce_chrome_web(args)
 elsif platform == "firefox_web"
   sanity_check "privly-web"
-  configure_for_firefox_web
+  configure_for_firefox_web(args)
 elsif platform == "chrome_web"
   sanity_check "privly-web"
-  configure_for_chrome_web
+  configure_for_chrome_web(args)
 elsif platform == "firefox_extension"
   sanity_check "privly-firefox"
-  configure_for_firefox_extension
+  configure_for_firefox_extension(args)
 elsif platform == "sauce_firefox_extension"
   sanity_check "privly-firefox"
-  configure_for_sauce_firefox_extension
+  configure_for_sauce_firefox_extension(args)
 elsif platform == "chrome_extension"
   sanity_check "privly-chrome"
-  configure_for_chrome_extension
+  configure_for_chrome_extension(args)
 elsif platform == "sauce_chrome_extension"
   sanity_check "privly-chrome"
-  configure_for_sauce_chrome_extension
+  configure_for_sauce_chrome_extension(args)
 else
   puts "The platform you selected was not recognized or is not supported"
   puts "Note that Safari and Internet Explorer are integrated"

--- a/test/selenium/specs/tc_extension_options.rb
+++ b/test/selenium/specs/tc_extension_options.rb
@@ -42,7 +42,6 @@ class TestOptions < Test::Unit::TestCase
     page.driver.browser.get(@options_url)
     elements = page.all(:css, '.whitelist_url')
     elements[0].set 'Dev.Privly.Org.phish.org'
-    click_button 'save_whitelist'
     page.driver.browser.get("http://test.privly.org/test_pages/nonwhitelist.html")
     assert page.has_xpath?('//iframe')
 

--- a/test/selenium/tc_chrome_helper.rb
+++ b/test/selenium/tc_chrome_helper.rb
@@ -1,0 +1,33 @@
+class ChromeHelper < Test::Unit::TestCase
+  include Capybara::DSL # Provides for Webdriving
+
+  # Ensure that the proper URL for the browser is assigned
+  def test_assigned_url
+
+    # Give the first-run page 15 seconds to appear
+    for i in 0..15
+      newest_window = page.driver.browser.window_handles.last
+      page.driver.switch_to_window newest_window
+      address = page.driver.browser.current_url
+      if address.include? "chrome-extension://"
+        break
+      end
+      if i == 15
+        puts "failed to recover Chrome extension URL for testing"
+        assert false
+        exit 1
+      end
+      sleep 1
+    end
+    app_host = "chrome-extension://" + address.split("/")[2]
+    Capybara.app_host = app_host
+    @@privly_applications_folder_path = Capybara.app_host + "/privly-applications/"
+    @@privly_test_set.each {|t|
+      t[:url] = @@privly_applications_folder_path + t[:url]
+    }
+  end
+  def teardown
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
+end


### PR DESCRIPTION
This pull request:

* Refactors the integration test configurations to be more manageable. This includes placing all the configurations into their own functions.
* I hacked together a solution for getting the chrome extension ID dynamically. People were experiencing a problem where the extension ID would mysteriously change and render the extension path invalid. The hack loads a test case to grab the ID before the other tests run by grabbing it from the first-run page.
* I also fixed a broken options page test.
* I ran this for all the platform combinations, including SauceLabs, but I have not run it from TravisCI yet.