### PR TITLE
Update test to take command line arguments

### DIFF
--- a/test/karma.conf-ci.js
+++ b/test/karma.conf-ci.js
@@ -2,6 +2,9 @@ var fs = require('fs');
 
 module.exports = function(config) {
 
+  // Configure the basePath to be the current working directory
+  var basePath = process.cwd();
+
   // Use ENV vars on Travis and sauce.json locally to get credentials
   if (!process.env.SAUCE_USERNAME) {
     if (!fs.existsSync('sauce.json')) {
@@ -25,25 +28,29 @@ module.exports = function(config) {
   // The .travis.yml file can also pass in other files
   // by exporting an environment variable containing a list of
   // Javascripts.
-  var filesToTest = [
+  var filesToTest = [];
+  if (basePath === __dirname) {
+    basePath = '..';
+    filesToTest = [
 
-    // HTML files to use as a fixtures
-    '*/*.html',
+      // HTML files to use as a fixtures
+      '*/*.html',
 
-    // Force jquery to load first since it is a dependency
-    'vendor/jquery.min.js',
+      // Force jquery to load first since it is a dependency
+      'vendor/jquery.min.js',
 
-    // Load all the vendor libraries
-    'vendor/*.js',
-    'vendor/datatables/jquery.dataTables.min.js',
-    'vendor/datatables/dataTables.bootstrap.min.js',
-    'vendor/bootstrap/js/*.js',
+      // Load all the vendor libraries
+      'vendor/*.js',
+      'vendor/datatables/jquery.dataTables.min.js',
+      'vendor/datatables/dataTables.bootstrap.min.js',
+      'vendor/bootstrap/js/*.js',
 
-    // Load all the shared libraries at the top level
-    'shared/javascripts/*.js',
+      // Load all the shared libraries at the top level
+      'shared/javascripts/*.js',
 
-    // Test the shared libraries
-    'shared/test/*.js'];
+      // Test the shared libraries
+      'shared/test/*.js'];
+  }
 
   var filesToExcludeFromTest = [];
   if (process.env.FILES_TO_TEST) {
@@ -53,29 +60,55 @@ module.exports = function(config) {
     filesToExcludeFromTest = filesToExcludeFromTest.concat(process.env.FILES_TO_EXCLUDE_FROM_TEST.split(","));
   }
 
-  // Browsers to run on Sauce Labs
-  var customLaunchers = {
-    'sl_chrome': {
-      base: 'SauceLabs',
-      browserName: 'chrome',
-      platform: 'Windows 7',
-      version: 'dev'
-    },
-    'sl_firefox': {
-      base: 'SauceLabs',
-      browserName: 'firefox',
-      version: 'dev'
-    },
-    'sl_safari': {
-      base: 'SauceLabs',
-      browserName: 'safari'
+  // Define the different types of browsers
+  var sl_chrome = {
+    base: 'SauceLabs',
+    browserName: 'chrome',
+    platform: 'Windows 7',
+    version: 'dev'
+  }
+  var sl_firefox = {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    version: 'dev'
+  }
+  var sl_safari = {
+    base: 'SauceLabs',
+    browserName: 'safari'
+  }
+
+  // Browsers to run on Sauce Labs based on command line argument
+  var customLaunchers = {};
+  process.argv.forEach(function (value, index, array) {
+    if (value.indexOf('--sauce-browsers=') == 0) {
+      var sauceBrowsers = value.split('=')[1];
+      sauceBrowsers = sauceBrowsers.split(',');
+      sauceBrowsers.forEach(function (browser) {
+        if (browser == 'chrome') {
+          customLaunchers['sl_chrome'] = sl_chrome;
+        }
+        else if (browser == 'firefox') {
+          customLaunchers['sl_firefox'] = sl_firefox;
+        }
+        else if (browser == 'safari') {
+          customLaunchers['sl_safari'] = sl_safari;
+        }
+      });
     }
-  };
+  });
+
+  // If no command line argument has been passed for specific browsers, run
+  // the tests on all the available browsers
+  if (Object.keys(customLaunchers).length == 0) {
+    customLaunchers['sl_chrome'] = sl_chrome;
+    customLaunchers['sl_firefox'] = sl_firefox;
+    customLaunchers['sl_safari'] = sl_safari;
+  }
 
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '..',
+    basePath: basePath,
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -3,29 +3,36 @@
 
 module.exports = function(config) {
 
+  // Configure the basePath to be the current working directory
+  var basePath = process.cwd();
+
   // List the files that you want to always test here.
   // The .travis.yml file can also pass in other files
   // by exporting an environment variable containing a list of
   // Javascripts.
-  var filesToTest = [
+  var filesToTest = [];
+  if (basePath === __dirname) {
+    basePath = '..';
+    filesToTest = [
 
-    // HTML files to use as a fixtures
-    '*/*.html',
+      // HTML files to use as a fixtures
+      '*/*.html',
 
-    // Force jquery to load first since it is a dependency
-    'vendor/jquery.min.js',
+      // Force jquery to load first since it is a dependency
+      'vendor/jquery.min.js',
 
-    // Load all the vendor libraries
-    'vendor/*.js',
-    'vendor/datatables/jquery.dataTables.min.js',
-    'vendor/datatables/dataTables.bootstrap.min.js',
-    'vendor/bootstrap/js/*.js',
+      // Load all the vendor libraries
+      'vendor/*.js',
+      'vendor/datatables/jquery.dataTables.min.js',
+      'vendor/datatables/dataTables.bootstrap.min.js',
+      'vendor/bootstrap/js/*.js',
 
-    // Load all the shared libraries at the top level
-    'shared/javascripts/*.js',
+      // Load all the shared libraries at the top level
+      'shared/javascripts/*.js',
 
-    // Test the shared libraries
-    'shared/test/*.js'];
+      // Test the shared libraries
+      'shared/test/*.js'];
+  }
 
   var filesToExcludeFromTest = [];
   if (process.env.FILES_TO_TEST) {
@@ -38,7 +45,7 @@ module.exports = function(config) {
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '..',
+    basePath: basePath,
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
@@ -94,7 +101,7 @@ module.exports = function(config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: ['Chrome', 'Firefox'],
+    browsers: ['Firefox'],
 
 
     // Continuous Integration mode

--- a/test/run_each.sh
+++ b/test/run_each.sh
@@ -8,6 +8,9 @@ echo "This will run all the tests currently defined in run_each.sh"
 echo "You can also have tests run every time you save a file by defining the scripts you want to test with:"
 echo "export FILES_TO_TEST=YOUR_FILES_HERE"
 echo "Then you can issue 'karma start'"
+echo "Currently, the tests are run only in the Firefox browser"
+echo "To test on different browsers, you can do:"
+echo "export BROWSERS_TO_TEST=Chrome,Firefox,Safari"
 echo "!!!!!!"
 
 # Default to running the tests locally
@@ -26,7 +29,15 @@ runTest () {
   echo ""
   echo "running tests on shared libraries and $1"
   echo ""
-  export FILES_TO_TEST=$1 && karma start $KARMA --single-run
+  export FILES_TO_TEST=$1
+  # By default, run tests on the Firefox browser
+  # If the BROWSERS_TO_TEST environment variable is set, run the tests on different browsers
+  if [ "$BROWSERS_TO_TEST" == "" ]
+  then
+    karma start $KARMA --single-run
+  else
+    karma start $KARMA --single-run --browsers "$BROWSERS_TO_TEST"
+  fi
   ISFAIL=$(($ISFAIL|$?))
 }
 


### PR DESCRIPTION
Rather than having a separate testing suite for the Safari extension, the Karma Test Runner should support taking command line arguments so that the extension tests can be run using the privly-applications test runner itself.