### PR TITLE
Allow reuse of 'ls' shim

### DIFF
--- a/shared/javascripts/local_storage.js
+++ b/shared/javascripts/local_storage.js
@@ -26,7 +26,7 @@ var ls = {
     if ( ls.localStorageDefined ) {
       localStorage.setItem(key, value);
     } else {
-      ls.preferences.setCharPref(key, value);
+      ls.storage[key] = value;
     }
 
     return value;
@@ -55,10 +55,10 @@ var ls = {
     } else {
       try {
         try { // try to parse stored value as JSON
-          var value = JSON.parse(ls.preferences.getCharPref(key));
+          var value = JSON.parse(ls.storage[key]);
           return value;
         } catch(e){
-          return ls.preferences.getCharPref(key);
+          return ls.storage[key];
         }
       } catch(e) {
         console.warn("Local Storage key was not in storage");
@@ -78,7 +78,7 @@ var ls = {
       return localStorage.removeItem(key);
     } else {
       try {
-        ls.preferences.clearUserPref(key);
+        delete ls.storage[key];
       } catch(e) {
         console.warn("Local Storage key was not in storage when it was removed");
       }
@@ -95,10 +95,12 @@ try {
   try {
     localStorage;
   } catch(e) {
+    // Firefox simple storage 
     ls.localStorageDefined = false;
-    // firefox 'chrome' environment
-    ls.preferences = Components.classes["@mozilla.org/preferences-service;1"].
-                       getService(Components.interfaces.nsIPrefService).
-                       getBranch("extensions.privly.");
+    const PrivlyStorage = Components.classes["@privly/storage;1"].
+                            getService(Components.interfaces.nsISupports).
+                            wrappedJSObject;
+    var ss = PrivlyStorage.getSimpleStorage();
+    ls.storage = ss.storage;
   }
 }

--- a/shared/javascripts/local_storage.js
+++ b/shared/javascripts/local_storage.js
@@ -87,14 +87,18 @@ var ls = {
   }
 };
 
-// Determine whether localstorage can be used directly
-try { 
-  localStorage;
+try {
+  // check for jetpack runtime environment
+  exports.ls = ls;
 } catch(e) {
-  ls.localStorageDefined = false;
-  
-  // Assuming Xul firefox
-  ls.preferences = Components.classes["@mozilla.org/preferences-service;1"]
-                         .getService(Components.interfaces.nsIPrefService)
-                         .getBranch("extensions.privly.");
+  // Determine whether localstorage can be used directly
+  try {
+    localStorage;
+  } catch(e) {
+    ls.localStorageDefined = false;
+    // firefox 'chrome' environment
+    ls.preferences = Components.classes["@mozilla.org/preferences-service;1"].
+                       getService(Components.interfaces.nsIPrefService).
+                       getBranch("extensions.privly.");
+  }
 }


### PR DESCRIPTION
These changes are necessary so that the "ls" shim can be re-used in Jetpack, as mentioned [here](https://github.com/privly/privly-jetpack/pull/3)