### PR TITLE
Add Safari to Unit Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
   - secure: HAqHN7zeSbDR7BP0pn6qH6ODOwuMD7eIR9t4h1gHkRy6WAQBrhQb1+kTzkGbhfKB1mftxN/0ERTK6xv+iBj4QylqOOXChnuthuHMZiAuwPJncj8FYE4LHt2Eh48+HnzSQUgzjxv11hvkLz4utaj0J4fub2q/tWzoAXucA13UGQU=
 script:
 - cd test
+- export BROWSERS_TO_TEST=Chrome,Firefox,Safari # test all the browsers
 - "if [ ${TRAVIS_PULL_REQUEST} = 'false' ]; then ./run_each.sh karma.conf-ci.js; fi"
 - "cd .."
 # Move the lcov.info file to the root

--- a/test/README.md
+++ b/test/README.md
@@ -48,7 +48,10 @@ found below from this directory.
 
 > karma start
 
-Two browsers should open and run your tests every time you save them.
+Firefox should open and run your tests every time you save them.
+If you want different browsers to run, you can specify them in CSVs:
+
+> karma start --browsers Firefox,Chrome,Safari
 
 ### Running on Sauce Labs ###
 
@@ -59,13 +62,27 @@ you can also hook your local dev environment into SauceLabs by
 first associating your machine with Sauce Labs (see below), then
 issuing:
 
-> karma start karma.conf-ci.js
+Firefox should open and run your tests every time you save them.
+If you want different browsers to run, you can specify them in CSVs:
 
-For more details on how this was setup, see:
-https://docs.saucelabs.com/tutorials/js-unit-testing/
+> karma start karma.conf-ci.js --sauce-browsers=Firefox,Chrome,Safari
+
+For more details on how this was setup, see [SauceLab's tutorial](https://docs.saucelabs.com/tutorials/js-unit-testing/). There is different
+syntax for selecting browsers because the default syntax breaks the ability to
+run tests on SauceLabs.
 
 If you want your tests to run on the Continuous Integration server, you should
-appropriately edit the .travis.yml file to include your test set.
+appropriately edit the run_each.sh file to include your test set.
+
+### Running All the Tests ###
+
+This directory contains the script `run_each.sh` that will run all the test sets it defines.
+You can tell run_each to open a particular set of browsers by exporting an environment variable first:
+
+> export BROWSERS_TO_TEST=Firefox,Chrome,Safari
+> ./run_each.sh [karma config file]
+
+The Karma config variable defaults to running karma.conf.js which runs the tests locally.
 
 # Writing Your Own Unit Tests
 
@@ -114,7 +131,7 @@ Try adding:
 
 If that worked, it is time to learn the Jasmine syntax these tests are written in.
 
-## Jasmine Crash Course ## 
+## Jasmine Crash Course ##
 
 You should read through the [Jasmine docs](http://jasmine.github.io/2.0/introduction.html) to learn how to write Jasmine tests. It is a quick read and it will be *very* useful for writing good tests.
 

--- a/test/karma.conf-ci.js
+++ b/test/karma.conf-ci.js
@@ -84,14 +84,21 @@ module.exports = function(config) {
       var sauceBrowsers = value.split('=')[1];
       sauceBrowsers = sauceBrowsers.split(',');
       sauceBrowsers.forEach(function (browser) {
-        if (browser == 'chrome') {
+        if (browser == 'Chrome') {
           customLaunchers['sl_chrome'] = sl_chrome;
         }
-        else if (browser == 'firefox') {
+        else if (browser == 'Firefox') {
           customLaunchers['sl_firefox'] = sl_firefox;
         }
-        else if (browser == 'safari') {
+        else if (browser == 'Safari') {
           customLaunchers['sl_safari'] = sl_safari;
+        }
+        else {
+          console.error("You specified an unsupported browser:", browser);
+          console.log("Browser options are Firefox, Chrome, and Safari");
+          console.log("Example:");
+          console.log("`karma start karma.conf-ci.js --sauce-browsers=Firefox,Chrome,Safari`");
+          process.exit(9);
         }
       });
     }

--- a/test/karma.conf-ci.js
+++ b/test/karma.conf-ci.js
@@ -2,6 +2,9 @@ var fs = require('fs');
 
 module.exports = function(config) {
 
+  // Configure the basePath to be the current working directory
+  var basePath = process.cwd();
+
   // Use ENV vars on Travis and sauce.json locally to get credentials
   if (!process.env.SAUCE_USERNAME) {
     if (!fs.existsSync('sauce.json')) {
@@ -25,25 +28,29 @@ module.exports = function(config) {
   // The .travis.yml file can also pass in other files
   // by exporting an environment variable containing a list of
   // Javascripts.
-  var filesToTest = [
+  var filesToTest = [];
+  if (basePath === __dirname) {
+    basePath = '..';
+    filesToTest = [
 
-    // HTML files to use as a fixtures
-    '*/*.html',
+      // HTML files to use as a fixtures
+      '*/*.html',
 
-    // Force jquery to load first since it is a dependency
-    'vendor/jquery.min.js',
+      // Force jquery to load first since it is a dependency
+      'vendor/jquery.min.js',
 
-    // Load all the vendor libraries
-    'vendor/*.js',
-    'vendor/datatables/jquery.dataTables.min.js',
-    'vendor/datatables/dataTables.bootstrap.min.js',
-    'vendor/bootstrap/js/*.js',
+      // Load all the vendor libraries
+      'vendor/*.js',
+      'vendor/datatables/jquery.dataTables.min.js',
+      'vendor/datatables/dataTables.bootstrap.min.js',
+      'vendor/bootstrap/js/*.js',
 
-    // Load all the shared libraries at the top level
-    'shared/javascripts/*.js',
+      // Load all the shared libraries at the top level
+      'shared/javascripts/*.js',
 
-    // Test the shared libraries
-    'shared/test/*.js'];
+      // Test the shared libraries
+      'shared/test/*.js'];
+  }
 
   var filesToExcludeFromTest = [];
   if (process.env.FILES_TO_TEST) {
@@ -53,29 +60,55 @@ module.exports = function(config) {
     filesToExcludeFromTest = filesToExcludeFromTest.concat(process.env.FILES_TO_EXCLUDE_FROM_TEST.split(","));
   }
 
-  // Browsers to run on Sauce Labs
-  var customLaunchers = {
-    'sl_chrome': {
-      base: 'SauceLabs',
-      browserName: 'chrome',
-      platform: 'Windows 7',
-      version: 'dev'
-    },
-    'sl_firefox': {
-      base: 'SauceLabs',
-      browserName: 'firefox',
-      version: 'dev'
-    },
-    'sl_safari': {
-      base: 'SauceLabs',
-      browserName: 'safari'
+  // Define the different types of browsers
+  var sl_chrome = {
+    base: 'SauceLabs',
+    browserName: 'chrome',
+    platform: 'Windows 7',
+    version: 'dev'
+  }
+  var sl_firefox = {
+    base: 'SauceLabs',
+    browserName: 'firefox',
+    version: 'dev'
+  }
+  var sl_safari = {
+    base: 'SauceLabs',
+    browserName: 'safari'
+  }
+
+  // Browsers to run on Sauce Labs based on command line argument
+  var customLaunchers = {};
+  process.argv.forEach(function (value, index, array) {
+    if (value.indexOf('--sauce-browsers=') == 0) {
+      var sauceBrowsers = value.split('=')[1];
+      sauceBrowsers = sauceBrowsers.split(',');
+      sauceBrowsers.forEach(function (browser) {
+        if (browser == 'chrome') {
+          customLaunchers['sl_chrome'] = sl_chrome;
+        }
+        else if (browser == 'firefox') {
+          customLaunchers['sl_firefox'] = sl_firefox;
+        }
+        else if (browser == 'safari') {
+          customLaunchers['sl_safari'] = sl_safari;
+        }
+      });
     }
-  };
+  });
+
+  // If no command line argument has been passed for specific browsers, run
+  // the tests on all the available browsers
+  if (Object.keys(customLaunchers).length == 0) {
+    customLaunchers['sl_chrome'] = sl_chrome;
+    customLaunchers['sl_firefox'] = sl_firefox;
+    customLaunchers['sl_safari'] = sl_safari;
+  }
 
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '..',
+    basePath: basePath,
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -3,29 +3,36 @@
 
 module.exports = function(config) {
 
+  // Configure the basePath to be the current working directory
+  var basePath = process.cwd();
+
   // List the files that you want to always test here.
   // The .travis.yml file can also pass in other files
   // by exporting an environment variable containing a list of
   // Javascripts.
-  var filesToTest = [
+  var filesToTest = [];
+  if (basePath === __dirname) {
+    basePath = '..';
+    filesToTest = [
 
-    // HTML files to use as a fixtures
-    '*/*.html',
+      // HTML files to use as a fixtures
+      '*/*.html',
 
-    // Force jquery to load first since it is a dependency
-    'vendor/jquery.min.js',
+      // Force jquery to load first since it is a dependency
+      'vendor/jquery.min.js',
 
-    // Load all the vendor libraries
-    'vendor/*.js',
-    'vendor/datatables/jquery.dataTables.min.js',
-    'vendor/datatables/dataTables.bootstrap.min.js',
-    'vendor/bootstrap/js/*.js',
+      // Load all the vendor libraries
+      'vendor/*.js',
+      'vendor/datatables/jquery.dataTables.min.js',
+      'vendor/datatables/dataTables.bootstrap.min.js',
+      'vendor/bootstrap/js/*.js',
 
-    // Load all the shared libraries at the top level
-    'shared/javascripts/*.js',
+      // Load all the shared libraries at the top level
+      'shared/javascripts/*.js',
 
-    // Test the shared libraries
-    'shared/test/*.js'];
+      // Test the shared libraries
+      'shared/test/*.js'];
+  }
 
   var filesToExcludeFromTest = [];
   if (process.env.FILES_TO_TEST) {
@@ -38,7 +45,7 @@ module.exports = function(config) {
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '..',
+    basePath: basePath,
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
@@ -94,7 +101,7 @@ module.exports = function(config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: ['Chrome', 'Firefox'],
+    browsers: ['Firefox'],
 
 
     // Continuous Integration mode

--- a/test/run_each.sh
+++ b/test/run_each.sh
@@ -30,13 +30,23 @@ runTest () {
   echo "running tests on shared libraries and $1"
   echo ""
   export FILES_TO_TEST=$1
+
   # By default, run tests on the Firefox browser
-  # If the BROWSERS_TO_TEST environment variable is set, run the tests on different browsers
+  # If the BROWSERS_TO_TEST environment variable is set,
+  # run the tests on the specified browsers
   if [ "$BROWSERS_TO_TEST" == "" ]
   then
     karma start $KARMA --single-run
   else
-    karma start $KARMA --single-run --browsers "$BROWSERS_TO_TEST"
+
+    # Since the `--browsers` option will circumvent the custom launchers
+    # of the CI we need to specify it a different way
+    if [ "$KARMA" == "karma.conf-ci.js" ]
+    then
+      karma start $KARMA --single-run --sauce-browsers="$BROWSERS_TO_TEST"
+    else
+      karma start $KARMA --single-run --browsers "$BROWSERS_TO_TEST"
+    fi
   fi
   ISFAIL=$(($ISFAIL|$?))
 }

--- a/test/run_each.sh
+++ b/test/run_each.sh
@@ -8,6 +8,9 @@ echo "This will run all the tests currently defined in run_each.sh"
 echo "You can also have tests run every time you save a file by defining the scripts you want to test with:"
 echo "export FILES_TO_TEST=YOUR_FILES_HERE"
 echo "Then you can issue 'karma start'"
+echo "Currently, the tests are run only in the Firefox browser"
+echo "To test on different browsers, you can do:"
+echo "export BROWSERS_TO_TEST=Chrome,Firefox,Safari"
 echo "!!!!!!"
 
 # Default to running the tests locally
@@ -26,7 +29,15 @@ runTest () {
   echo ""
   echo "running tests on shared libraries and $1"
   echo ""
-  export FILES_TO_TEST=$1 && karma start $KARMA --single-run
+  export FILES_TO_TEST=$1
+  # By default, run tests on the Firefox browser
+  # If the BROWSERS_TO_TEST environment variable is set, run the tests on different browsers
+  if [ "$BROWSERS_TO_TEST" == "" ]
+  then
+    karma start $KARMA --single-run
+  else
+    karma start $KARMA --single-run --browsers "$BROWSERS_TO_TEST"
+  fi
   ISFAIL=$(($ISFAIL|$?))
 }
 


### PR DESCRIPTION
This pull request adds Safari support for TravisCI as well as local tests. A few notes:

* I am merging this with the "develop" branch. Most new pull requests should be made against this branch.
* When launched without specifying a browser the unit tests default to launching Firefox.
* There is a new option for specifying which browsers you want to run the tests on. Before issuing ./run_each.sh you can `export BROWSERS_TO_TEST=Firefox,Chrome,Safari` or any browser subset thereof.
* You can also continue to use Karma's method of specifying browsers when the tests are running locally, `karma start --browsers Firefox,Chrome,Safari`.
* Or you can specify browsers for the SauceLabs script with: `karma start karma.conf-ci.js --single-run --sauce-browsers=Firefox,Chrome,Safari`
* The three different arguments are necessary because `--browsers` will break the SauceLabs script.

Special thanks to @sammyshj for figuring out the argument conflicts.

Closes #241 