### PR TITLE
requires path module to support absolute path for basePath

### DIFF
--- a/test/karma.conf-ci.js
+++ b/test/karma.conf-ci.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var path = require('path');
 
 module.exports = function(config) {
 
@@ -7,7 +8,7 @@ module.exports = function(config) {
 
   // Use ENV vars on Travis and sauce.json locally to get credentials
   if (!process.env.SAUCE_USERNAME) {
-    if (!fs.existsSync('sauce.json')) {
+    if (!fs.existsSync(path.join(__dirname, 'sauce.json'))) {
       console.log('Create a sauce.json with your credentials based on the sauce-sample.json file.');
       process.exit(1);
     } else {
@@ -30,7 +31,6 @@ module.exports = function(config) {
   // Javascripts.
   var filesToTest = [];
   if (basePath === __dirname) {
-    basePath = '..';
     filesToTest = [
 
       // HTML files to use as a fixtures
@@ -51,6 +51,8 @@ module.exports = function(config) {
       // Test the shared libraries
       'shared/test/*.js'];
   }
+
+  basePath = path.join(basePath, '..');
 
   var filesToExcludeFromTest = [];
   if (process.env.FILES_TO_TEST) {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,5 +1,6 @@
 // Karma configuration
 // Generated on Thu Mar 13 2014 14:12:04 GMT-0700 (PDT)
+var path = require('path');
 
 module.exports = function(config) {
 
@@ -12,7 +13,6 @@ module.exports = function(config) {
   // Javascripts.
   var filesToTest = [];
   if (basePath === __dirname) {
-    basePath = '..';
     filesToTest = [
 
       // HTML files to use as a fixtures
@@ -33,6 +33,8 @@ module.exports = function(config) {
       // Test the shared libraries
       'shared/test/*.js'];
   }
+
+  basePath = path.join(basePath, '..');
 
   var filesToExcludeFromTest = [];
   if (process.env.FILES_TO_TEST) {


### PR DESCRIPTION
Presently, we are trying to run the Safari extension tests using the privly-applications Karma Test Runner. However, when the `karma.conf-ci.js` script is run from a different directory, `fs.existsSync('sauce.json')` searches for `sauce.json` file in that directory. This is fixed in this PR and the `sauce.json` is now searched for in the test directory itself.
When both the karma scripts are run from a different directory, the coverage is reported in the `test/test/coverage/` directory. This PR fixes that and now the coverage is reported in `test/coverage/` directory.