### PR TITLE
Update chrome testing

### DIFF
--- a/Help/test/new.js
+++ b/Help/test/new.js
@@ -13,7 +13,8 @@ describe ("Help New Suite", function() {
       "messages",
       "login_message",
       "refresh_link",
-      "form"
+      "form",
+      "logout_link"
     ];
     domIDs.forEach(function(id){
       var newElement = $('<a/>', {
@@ -34,7 +35,6 @@ describe ("Help New Suite", function() {
     var oldInit = privlyNetworkService.initPrivlyService;
     var oldInitNav = privlyNetworkService.initializeNavigation;
     privlyNetworkService.initPrivlyService = function(){};
-    privlyNetworkService.initializeNavigation = function(){};
 
     // Call the test
     callbacks.pendingLogin();

--- a/test/karma.conf-ci.js
+++ b/test/karma.conf-ci.js
@@ -2,8 +2,22 @@ var fs = require('fs');
 
 module.exports = function(config) {
 
-  // Configure the basePath to be the current working directory
-  var basePath = process.cwd();
+  // If the script is not being executed from the testing directory
+  if(process.cwd() !== __dirname) {
+    console.warn(
+      "\n!!!\nYou are running this script from outside the test directory. " +
+      "If you do not have the required node modules on your NODE_PATH, " +
+      "you will not be able to run these tests.\n!!!\n");
+    console.warn(
+      "You may need to issue something like: " +
+      "`export NODE_PATH=/PATH/TO/privly-applications/test/node_modules");
+  }
+
+  // Force the script to execute from its directory
+  process.chdir(__dirname);
+
+  // All files will be referenced relative to the privly-applications folder
+  var basePath = "..";
 
   // Use ENV vars on Travis and sauce.json locally to get credentials
   if (!process.env.SAUCE_USERNAME) {
@@ -29,25 +43,6 @@ module.exports = function(config) {
   // by exporting an environment variable containing a list of
   // Javascripts.
   var filesToTest = [];
-  if (basePath === __dirname) {
-    basePath = '..';
-    filesToTest = [
-
-       // Force jquery to load first since it is a dependency
-      'vendor/jquery.min.js',
-
-      // Load all the vendor libraries
-      'vendor/*.js',
-      'vendor/datatables/jquery.dataTables.min.js',
-      'vendor/datatables/dataTables.bootstrap.min.js',
-      'vendor/bootstrap/js/*.js',
-
-      // Load all the shared libraries at the top level
-      'shared/javascripts/*.js',
-
-      // Test the shared libraries
-      'shared/test/*.js'];
-  }
 
   var filesToExcludeFromTest = [];
   if (process.env.FILES_TO_TEST) {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,35 +1,29 @@
 // Karma configuration
 // Generated on Thu Mar 13 2014 14:12:04 GMT-0700 (PDT)
-
 module.exports = function(config) {
 
-  // Configure the basePath to be the current working directory
-  var basePath = process.cwd();
+  // If the script is not being executed from the testing directory
+  if(process.cwd() !== __dirname) {
+    console.warn(
+      "\n!!!\nYou are running this script from outside the test directory. " +
+      "If you do not have the required node modules on your NODE_PATH, " +
+      "you will not be able to run these tests.\n!!!\n");
+    console.warn(
+      "You may need to issue something like: " +
+      "`export NODE_PATH=/PATH/TO/privly-applications/test/node_modules");
+  }
+
+  // Force the script to execute from its directory
+  process.chdir(__dirname);
+
+  // All files will be referenced relative to the privly-applications folder
+  var basePath = "..";
 
   // List the files that you want to always test here.
   // The .travis.yml file can also pass in other files
   // by exporting an environment variable containing a list of
-  // Javascripts.
+  // Javascript file paths.
   var filesToTest = [];
-  if (basePath === __dirname) {
-    basePath = '..';
-    filesToTest = [
-
-      // Force jquery to load first since it is a dependency
-      'vendor/jquery.min.js',
-
-      // Load all the vendor libraries
-      'vendor/*.js',
-      'vendor/datatables/jquery.dataTables.min.js',
-      'vendor/datatables/dataTables.bootstrap.min.js',
-      'vendor/bootstrap/js/*.js',
-
-      // Load all the shared libraries at the top level
-      'shared/javascripts/*.js',
-
-      // Test the shared libraries
-      'shared/test/*.js'];
-  }
 
   var filesToExcludeFromTest = [];
   if (process.env.FILES_TO_TEST) {

--- a/test/run_each.sh
+++ b/test/run_each.sh
@@ -27,7 +27,7 @@ declare -i ISFAIL=0
 
 runTest () {
   echo ""
-  echo "running tests on shared libraries and $1"
+  echo "running tests on $1"
   echo ""
   export FILES_TO_TEST=$1
 
@@ -51,15 +51,18 @@ runTest () {
   ISFAIL=$(($ISFAIL|$?))
 }
 
+# These are the scripts that will be loaded for every test
+commonScripts="vendor/jquery.min.js,vendor/*.js,vendor/datatables/jquery.dataTables.min.js,vendor/datatables/dataTables.bootstrap.min.js,vendor/bootstrap/js/*.js,shared/javascripts/*.js,shared/test/*.js"
+
 # Each line below executes the scripts in order in the context of the browsers.
-runTest 'Help/js/*.js,Help/test/*.js'
-runTest 'History/js/*.js,History/test/*.js'
-runTest 'Login/js/*.js,Login/test/*.js'
-runTest 'Pages/js/options.js,Pages/js/tests/*.js'
-runTest 'shared/javascripts/privly-web/new.js,PlainPost/js/new.js,PlainPost/test/new.js'
-runTest 'shared/javascripts/privly-web/show.js,PlainPost/js/show.js,PlainPost/test/show.js'
-runTest 'shared/javascripts/privly-web/new.js,Message/js/base64.js,Message/js/rawdeflate.js,Message/js/rawinflate.js,Message/js/zerobin.js,Message/js/new.js,Message/test/new.js,Message/test/zerobin.js'
-runTest 'shared/javascripts/privly-web/show.js,Message/js/base64.js,Message/js/rawdeflate.js,Message/js/rawinflate.js,Message/js/zerobin.js,Message/js/show.js,Message/test/show.js,Message/test/zerobin.js'
+runTest "$commonScripts,Help/js/*.js,Help/test/*.js"
+runTest "$commonScripts,History/js/*.js,History/test/*.js"
+runTest "$commonScripts,Login/js/*.js,Login/test/*.js"
+runTest "$commonScripts,Pages/js/options.js,Pages/js/tests/*.js"
+runTest "$commonScripts,shared/javascripts/privly-web/new.js,PlainPost/js/new.js,PlainPost/test/new.js"
+runTest "$commonScripts,shared/javascripts/privly-web/show.js,PlainPost/js/show.js,PlainPost/test/show.js"
+runTest "$commonScripts,shared/javascripts/privly-web/new.js,Message/js/base64.js,Message/js/rawdeflate.js,Message/js/rawinflate.js,Message/js/zerobin.js,Message/js/new.js,Message/test/new.js,Message/test/zerobin.js"
+runTest "$commonScripts,shared/javascripts/privly-web/show.js,Message/js/base64.js,Message/js/rawdeflate.js,Message/js/rawinflate.js,Message/js/zerobin.js,Message/js/show.js,Message/test/show.js,Message/test/zerobin.js"
 
 if [ ! $ISFAIL -eq 0 ]
 then


### PR DESCRIPTION
This pull request updates the karma testing scripts to make it easier for them to be used from different extension contexts by removing the shared libraries from the karma scripts into the run_each.sh scripts.

When testing from an extension, you will likely need to export the node path to the testing modules:

`export NODE_PATH=/PATH/TO/privly-applications/test/node_modules`