### PR TITLE
Switched coverage reporter to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,11 @@ script:
 - cd test
 - export BROWSERS_TO_TEST=Chrome,Firefox,Safari # test all the browsers
 - "if [ ${TRAVIS_PULL_REQUEST} = 'false' ]; then ./run_each.sh karma.conf-ci.js; fi"
-- "cd .."
-# Move the lcov.info file to the root
-- "find . -name lcov.info -exec mv {} . \\;"
+- "./node_modules/.bin/lcov-result-merger 'coverage/*.lcov' 'coverage/combined.lcov'"
 # Send the file to CodeClimate
-- "if [ \"$CODECLIMATE_REPO_TOKEN\" ]; then codeclimate <  lcov.info; fi"
+- "cd .."
+- "cat ./test/coverage/combined.lcov | ./test/node_modules/coveralls/bin/coveralls.js"
 before_script:
 - "cd test/ && npm install -g karma-cli && npm install && cd .."
-- npm install -g codeclimate-test-reporter
 addons:
   sauce_connect: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,10 @@ env:
 script:
 - cd test
 - export BROWSERS_TO_TEST=Chrome,Firefox,Safari # test all the browsers
-- "if [ ${TRAVIS_PULL_REQUEST} = 'false' ]; then ./run_each.sh karma.conf-ci.js; fi"
-- "./node_modules/.bin/lcov-result-merger 'coverage/*.lcov' 'coverage/combined.lcov'"
-# Send the file to CodeClimate
+- "if [ ${TRAVIS_PULL_REQUEST} = 'false' ]; then ./run_each.sh karma.conf-ci.js; fi" # Run the unit tests
+- "if [ ${TRAVIS_PULL_REQUEST} = 'false' ]; then ./node_modules/.bin/lcov-result-merger 'coverage/*.lcov' 'coverage/combined.lcov'; fi" # Merge the coverage results
 - "cd .."
-- "cat ./test/coverage/combined.lcov | ./test/node_modules/coveralls/bin/coveralls.js"
+- "if [ ${TRAVIS_PULL_REQUEST} = 'false' ]; then cat ./test/coverage/combined.lcov | ./test/node_modules/coveralls/bin/coveralls.js; fi" # Send the coverage results to coveralls
 before_script:
 - "cd test/ && npm install -g karma-cli && npm install && cd .."
 addons:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ For more information on what Privly is,
 [![Build Status](https://travis-ci.org/privly/privly-applications.svg)](https://travis-ci.org/privly/privly-applications)
 [![Dependency Status](https://gemnasium.com/privly/privly-applications.png?travis)](https://gemnasium.com/privly/privly-applications)
 [![Code Climate](https://codeclimate.com/github/privly/privly-applications/badges/gpa.svg)](https://codeclimate.com/github/privly/privly-applications)
-[![Test Coverage](https://codeclimate.com/github/privly/privly-applications/badges/coverage.svg)](https://codeclimate.com/github/privly/privly-applications)
 
 This repository is oriented to cross-platform development of Privly 
 Applications, which are web applications viewed within the context of other web 

--- a/test/karma.conf-ci.js
+++ b/test/karma.conf-ci.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var uuid = require('uuid');
 
 module.exports = function(config) {
 
@@ -115,7 +116,7 @@ module.exports = function(config) {
 
     // Provide coverage information for the shared libraries
     preprocessors: {
-      'shared/javascripts/*.js': 'coverage'
+      '*/j*/*.js': 'coverage'
     },
 
     // list of files / patterns to load in the browser
@@ -124,14 +125,21 @@ module.exports = function(config) {
     // files to exclude from testing
     exclude: filesToExcludeFromTest,
 
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
+    // test result reporters to use
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['dots', 'coverage', 'saucelabs'],
+    reporters: ['dots', 'coverage', 'saucelabs', 'coveralls'],
 
     coverageReporter: {
       type : 'lcovonly',
       dir : 'test/coverage/'
+    },
+
+    // Where to save the coverage information to
+    coverageReporter: {
+      type : 'lcovonly',
+      dir : 'test/coverage/',
+      subdir: '.',
+      file : uuid.v1() + ".lcov"
     },
 
     // web server port

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -42,27 +42,17 @@ module.exports = function(config) {
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
     frameworks: ['jasmine'],
 
-    // Provide coverage information for the shared libraries
-    preprocessors: {
-      'shared/javascripts/*.js': 'coverage'
-    },
-
     // list of files / patterns to load in the browser
     files: filesToTest,
 
     // files to exclude from testing
     exclude: filesToExcludeFromTest,
 
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
+    // test result reporters to use
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress', 'coverage'],
-
-    coverageReporter: {
-      type : 'lcov',
-      dir : 'test/coverage/',
-      file : 'coverage.txt'
-    },
+    reporters: [
+      'progress'
+    ],
 
     // web server port
     port: 9876,

--- a/test/package.json
+++ b/test/package.json
@@ -10,12 +10,18 @@
   "author": "Sauce Labs",
   "license": "Apache V2",
   "devDependencies": {
+    "coveralls": "^2.11.2",
     "karma": "^0.12.31",
     "karma-chrome-launcher": "^0.1.7",
+    "karma-coverage": "~0.2",
+    "karma-coveralls": "^1.0.1",
     "karma-firefox-launcher": "^0.1.4",
     "karma-jasmine": "^0.3.5",
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.2.10",
-    "karma-coverage": "~0.2"
+    "lcov-result-merger": "^1.0.2"
+  },
+  "dependencies": {
+    "uuid": "^2.0.1"
   }
 }


### PR DESCRIPTION
This pull request switches from CodeClimate's test coverage reports to [coveralls.io](https://coveralls.io/), which gives line by line code coverage information. If you have TravisCI setup for your fork, you only need to create an account on [coveralls.io](https://coveralls.io/) and turn it on for your repository. You don't need to add an API key to the travis.yml file.