### PR TITLE
Added safari_web for selenium tests

### DIFF
--- a/test/selenium/configurations.rb
+++ b/test/selenium/configurations.rb
@@ -127,6 +127,13 @@ def configure_for_chrome_web(args)
   common_configuration_for_web(args)
 end
 
+def configure_for_safari_web(args)
+  common_configuration_for_web(args)
+  # Do not block pop-up windows in Safari
+  # https://macmule.com/2012/07/31/disabling-safari-5-1-xs-6-xs-pop-up-blocker-from-terminal-2/
+  `defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaScriptCanOpenWindowsAutomatically -bool true`
+end
+
 def configure_for_sauce_firefox_web(args)
   common_configuration_for_sauce
   common_configuration_for_sauce_web(args)

--- a/test/selenium/run_all.rb
+++ b/test/selenium/run_all.rb
@@ -17,7 +17,7 @@ args = {}
 optsHelp = ""
 OptionParser.new do |opts|
   opts.banner = "Usage: ruby run_all.rb [options]"
-  opts.on('-p', '--platform PLATFORM', 'The target platform (firefox_web, firefox_extension, chrome_web, chrome_extension, sauce_chrome_web, sauce_firefox_web, sauce_firefox_extension, sauce_chrome_extension)') { |v| args[:platform] = v }
+  opts.on('-p', '--platform PLATFORM', 'The target platform (firefox_web, firefox_extension, chrome_web, chrome_extension, safari_web, sauce_chrome_web, sauce_firefox_web, sauce_firefox_extension, sauce_chrome_extension)') { |v| args[:platform] = v }
   opts.on('-r', '--release-status RELEASE', 'The target release stage (experimental, deprecated, alpha, beta, release)') { |v| args[:release_status] = v }
   opts.on('-c', '--content-server SERVER', 'The content server (http://localhost:3000)') { |v| args[:content_server] = v }
   optsHelp = opts.help
@@ -100,8 +100,10 @@ end
 #                     This requires a webserver to run on localhost:3000
 #  sauce_chrome_extension: run Chrome on saucelabs with an extension.
 #  chrome_web: run Chrome locally without an extension.
-#               This requires a webserver to run on localhost:3000
+#              This requires a webserver to run on localhost:3000
 #  chrome_extension: run Chrome locally with an extension.
+#  safari_web: run Safari locally without an extension.
+#              This requires a webserver to run on localhost:3000
 if args[:platform]
   platform = args[:platform]
 end
@@ -148,6 +150,9 @@ elsif platform == "firefox_web"
 elsif platform == "chrome_web"
   sanity_check "privly-web"
   configure_for_chrome_web(args)
+elsif platform == "safari_web"
+  sanity_check "privly-web"
+  configure_for_safari_web(args)
 elsif platform == "firefox_extension"
   sanity_check "privly-firefox"
   configure_for_firefox_extension(args)

--- a/test/selenium/specs/auth_helper.rb
+++ b/test/selenium/specs/auth_helper.rb
@@ -36,9 +36,8 @@ module AuthHelper
     fill_in 'user_password', :with => password
     domain = page.evaluate_script('privlyNetworkService.contentServerDomain()');
     click_on ('Login to ' + domain)
-    Timeout.timeout(Capybara.default_wait_time) do
-      loop until page.evaluate_script('jQuery.active').zero?
-    end
+    wait = Selenium::WebDriver::Wait.new(:timeout => 3)
+    wait.until { page.evaluate_script('jQuery.active').zero? }
   end
 
   # Click he logout link on the current page then wait for the

--- a/test/selenium/specs/tc_new.rb
+++ b/test/selenium/specs/tc_new.rb
@@ -10,6 +10,7 @@ class TestNew < Test::Unit::TestCase
   def setup
     page.driver.browser.get(@@privly_test_set[0][:url])
     login(@@privly_test_set[0][:content_server])
+    page.driver.browser.manage.timeouts.implicit_wait = 3
   end
 
   # Test post creation for each application that presents a "new" action.
@@ -66,7 +67,7 @@ class TestNew < Test::Unit::TestCase
         find_button("Update").click
 
         # Refresh
-        page.driver.browser.get(page.evaluate_script("window.location.href"))
+        page.driver.browser.navigate.refresh
 
         # Make sure the refreshed page has the new content
         assert page.has_text?('Updated!')


### PR DESCRIPTION
Adds safari_web for selenium tests. This way we can run the selenium tests that already run on Chrome and Firefox to run on Safari too.