### PR TITLE
Coverage files are test specific now

### DIFF
--- a/test/karma.conf-ci.js
+++ b/test/karma.conf-ci.js
@@ -3,8 +3,22 @@ var uuid = require('uuid');
 
 module.exports = function(config) {
 
+  // These are the default coverageFiles. They should be updated when run from
+  // the privly-safari repo, https://github.com/privly/privly-safari
+  var coverageFiles = {
+    '*/j*/!(raw*).js': 'coverage'
+  };
+
   // If the script is not being executed from the testing directory
   if(process.cwd() !== __dirname) {
+
+    if(process.cwd().indexOf("privly-safari") != -1) {
+      // When the script is run from the privly-safari repo, update the coverageFiles
+      coverageFiles = {
+        '../scripts/*.js': 'coverage'
+      };
+    }
+
     console.warn(
       "\n!!!\nYou are running this script from outside the test directory. " +
       "If you do not have the required node modules on your NODE_PATH, " +
@@ -117,9 +131,7 @@ module.exports = function(config) {
     // Provide test coverage information for the matched
     // files. The compression library (both start with "raw")
     // is excluded.
-    preprocessors: {
-      '*/j*/!(raw*).js': 'coverage'
-    },
+    preprocessors: coverageFiles,
 
     // list of files / patterns to load in the browser
     files: filesToTest,


### PR DESCRIPTION
If the karma.conf-ci.js file is not run from the same directory, this means that the file has been run with the Safari run_each.sh script. In this case, we want to load coverage files under Safari extension's scripts directory only, https://github.com/privly/privly-safari/tree/master/privly.safariextension/scripts