### PR TITLE
Include all files recursively under scripts directory

### DIFF
--- a/test/karma.conf-ci.js
+++ b/test/karma.conf-ci.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
     if(process.cwd().indexOf("privly-safari") != -1) {
       // When the script is run from the privly-safari repo, update the coverageFiles
       coverageFiles = {
-        '../scripts/*.js': 'coverage'
+        '../scripts/**/*.js': 'coverage'
       };
     }
 


### PR DESCRIPTION
Presently, for the Safari extension, coverage is generated only for the [popover.js](https://github.com/privly/privly-safari/blob/master/privly.safariextension/scripts/popover.js) file.
This PR now includes coverage for all the files recursively inside the [scripts directory](https://github.com/privly/privly-safari/tree/master/privly.safariextension/scripts) for the Safari extension.