### PR TITLE
Added necessary javascript include files

### DIFF
--- a/shared/javascripts/network_service.js
+++ b/shared/javascripts/network_service.js
@@ -90,10 +90,12 @@ var privlyNetworkService = {
         return "IOS";
     } else if(typeof androidJsBridge !== "undefined") {
       return "ANDROID";
-    }  else if (typeof chrome !== "undefined" && typeof chrome.extension !== "undefined") {
+    } else if (typeof chrome !== "undefined" && typeof chrome.extension !== "undefined") {
       return "CHROME";
-    } else if(window.location.href.indexOf("chrome://") === 0) {
+    } else if (window.location.href.indexOf("chrome://") === 0) {
       return "FIREFOX";
+    } else if (window.location.href.indexOf("safari-extension://") === 0) {
+      return "SAFARI";
     } else {
       return "HOSTED";
     }
@@ -230,6 +232,7 @@ var privlyNetworkService = {
       return protocolDomainPort;
     } else if (platformName === "CHROME" ||
                platformName === "FIREFOX" ||
+               platformName === "SAFARI" ||
                platformName === "IOS") {
       return Privly.options.getServerUrl();
     } else if (platformName === "ANDROID") {

--- a/templates/base.html.template
+++ b/templates/base.html.template
@@ -14,6 +14,10 @@
 
     <script type="text/javascript" src="../shared/javascripts/meta_loader.js"></script>
     <script type="text/javascript" src="../shared/javascripts/parameters.js"></script>
+    <script type="text/javascript" src="../shared/javascripts/context_messenger.js"></script>
+    <script type="text/javascript" src="../shared/javascripts/glyph.js"></script>
+    <script type="text/javascript" src="../shared/javascripts/storage.js"></script>
+    <script type="text/javascript" src="../shared/javascripts/options.js"></script>
     <script type="text/javascript" src="../shared/javascripts/network_service.js"></script>
     <script type="text/javascript" src="../shared/javascripts/local_storage.js"></script>
 

--- a/templates/new.html.template
+++ b/templates/new.html.template
@@ -7,7 +7,6 @@
     <link class="top" href="../shared/css/top/top.css" rel="stylesheet"/>
     {% block css %}{% endblock %}
 
-    <script type="text/javascript" src="../shared/javascripts/extension_integration.js"></script>
     {% block javascripts %}{% endblock %}
 
 {% endblock %}


### PR DESCRIPTION
**The changes done in the PR:**
1. Included the javascript files `context_messenger.js`, `storage.js`, `glyph.js`, `options.js` to the privly-application pages
2. Removed the previously included javascript file `extension_integration.js` from the privly-application pages
3. The above mentioned privly-application pages include:
* Help/new.html
* History/new.html
* Login/new.html
* Message/new.html
* Message/show.html
* Pages/ChromeOptions.html
* PlainPost/new.html
* PlainPost/show.html

In `network_service.js`, the `platformName` function now returns `"SAFARI"` when run from the Safari extension.
@smcgregor The changes have been verified with the Safari extension and they work good now.