### PR TITLE
Send message from BACKGROUND_SCRIPT to BACKGROUND_SCRIPT

### DIFF
--- a/shared/javascripts/context_messenger.js
+++ b/shared/javascripts/context_messenger.js
@@ -435,7 +435,12 @@ if (Privly === undefined) {
   /** @inheritdoc */
   SafariAdapter.prototype.sendMessageTo = function (to, payload) {
     if (to === 'BACKGROUND_SCRIPT') {
-      safari.self.tab.dispatchMessage(payload);
+      if (this.getContextName() === 'BACKGROUND_SCRIPT') {
+        safari.self.contentWindow.postMessage(payload, '*');
+      }
+      else {
+        safari.self.tab.dispatchMessage(payload);
+      }
       return;
     }
     if (to === 'CONTENT_SCRIPT') {


### PR DESCRIPTION
Changes done in this PR:
* When a message is sent to a `BACKGROUND_SCRIPT` from a `BACKGROUND_SCRIPT`, the ` safari.self.contentWindow.postMessage()` function should be used. If the message is sent from a different script, the `safari.self.tab.dispatchMessage()` function should be used.