### PR TITLE
Load interface scripts as CommonJS modules, refactor Firefox Adapter

### DIFF
--- a/shared/javascripts/context_messenger.js
+++ b/shared/javascripts/context_messenger.js
@@ -415,8 +415,10 @@ if (Privly === undefined) {
     // Privly Applications can't send messages directly to background scripts, they do so via
     // content scripts injected in the application.
     if (contextName === "PRIVLY_APPLICATION") {
-      // Override the target so that the message doesn't get dropped.
-      data.to = "CONTENT_SCRIPT";
+      if (to === "BACKGROUND_SCRIPT" || to === "CONTENT_SCRIPT") {
+        // Override the target so that the message doesn't get dropped.
+        data.to = "CONTENT_SCRIPT";
+      }
       parent.postMessage(JSON.stringify(data), "*");
     } 
     // Messages from Content Script to Background Script, Privly-Applications.

--- a/shared/javascripts/glyph.js
+++ b/shared/javascripts/glyph.js
@@ -51,8 +51,7 @@ if (Privly === undefined) {
   if (typeof module !== "undefined" && module.exports) {
     module.exports.glyph = Privly.glyph;
     // load dependencies
-    var { options } = require("./options.js");
-    Privly.options = options;
+    Privly.options = require("./options.js").options;
   }
 
   /**

--- a/shared/javascripts/glyph.js
+++ b/shared/javascripts/glyph.js
@@ -47,6 +47,14 @@ if (Privly === undefined) {
   }
   Privly.glyph = {};
 
+  // CommonJS Module
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports.glyph = Privly.glyph;
+    // load dependencies
+    var { options } = require("./options.js");
+    Privly.options = options;
+  }
+
   /**
    * Get glyph color and cells
    */

--- a/shared/javascripts/glyph.js
+++ b/shared/javascripts/glyph.js
@@ -50,8 +50,12 @@ if (Privly === undefined) {
   // CommonJS Module
   if (typeof module !== "undefined" && module.exports) {
     module.exports.glyph = Privly.glyph;
-    // load dependencies
-    Privly.options = require("./options.js").options;
+    // load dependencies    
+    var optionsModule = require("./options.js");
+    Privly.options = optionsModule.options;
+    module.exports.options = optionsModule.options;
+    module.exports.storage = optionsModule.storage;
+    module.exports.message = optionsModule.message;
   }
 
   /**

--- a/shared/javascripts/local_storage.js
+++ b/shared/javascripts/local_storage.js
@@ -101,10 +101,10 @@ try {
   ls.localStorageDefined = false;
   // Use Preferences service instead of localStorage
   if (typeof module !== 'undefined' && module.exports) {
-    const { Cc, Ci } = require("chrome");
+    const components = require("chrome");
     // Preferences storage
-    ls.preferences = Cc["@mozilla.org/preferences-service;1"].
-                       getService(Ci.nsIPrefService).
+    ls.preferences = components.Cc["@mozilla.org/preferences-service;1"].
+                       getService(components.Ci.nsIPrefService).
                        getBranch("extensions.privly.");
     // Loaded as a CommonJS module, reused as a Local Storage shim 
     // in lib/local_storage.js.

--- a/shared/javascripts/local_storage.js
+++ b/shared/javascripts/local_storage.js
@@ -98,15 +98,21 @@ try {
   localStorage;
 } catch(e) {
   // Firefox
+  ls.localStorageDefined = false;
   // Use Preferences service instead of localStorage
   if (typeof module !== 'undefined' && module.exports) {
+    const { Cc, Ci } = require("chrome");
+    // Preferences storage
+    ls.preferences = Cc["@mozilla.org/preferences-service;1"].
+                       getService(Ci.nsIPrefService).
+                       getBranch("extensions.privly.");
     // Loaded as a CommonJS module, reused as a Local Storage shim 
     // in lib/local_storage.js.
-    module.exports.ls = ls;   
+    module.exports.ls = ls;
+
   } else {
     // Privileged JS code run in a firefox "chrome://" page. for eg:- ChromeFirstRun page.
     // Components can be accessed.
-    ls.localStorageDefined = false;
     // Preferences Storage
     ls.preferences = Components.classes["@mozilla.org/preferences-service;1"].
                        getService(Components.interfaces.nsIPrefService).

--- a/shared/javascripts/options.js
+++ b/shared/javascripts/options.js
@@ -68,10 +68,8 @@ if (Privly === undefined) {
     module.exports.options = Privly.options;
     // load dependencies
     ls = require("./local_storage.js").ls;
-    var { storage } = require("./storage.js");  
-    var { message } = require("./context_messenger.js");
-    Privly.storage = storage;
-    Privly.message = message;
+    Privly.storage = require("./storage.js").storage;
+    Privly.message = require("./context_messenger.js").message;
   }
 
 

--- a/shared/javascripts/options.js
+++ b/shared/javascripts/options.js
@@ -43,7 +43,7 @@
  *
  * - options/glyph {Object} A consistent visual identifier to prevent spoofing
  *     color {String} The cell color of the glyph.
- *     cells {[Boolean]} The bitmap of the glyp cell.
+ *     cells {[Boolean]} The bitmap of the glyph cell.
  * 
  */
 /*global chrome */
@@ -62,6 +62,18 @@ if (Privly === undefined) {
     return;
   }
   Privly.options = {};
+
+  // CommonJS Module
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports.options = Privly.options;
+    // load dependencies
+    ls = require("./local_storage.js").ls;
+    var { storage } = require("./storage.js");  
+    var { message } = require("./context_messenger.js");
+    Privly.storage = storage;
+    Privly.message = message;
+  }
+
 
   /**
    * Broadcast option changed message
@@ -117,7 +129,7 @@ if (Privly === undefined) {
     }
     // Glyph
     var glyphColor = ls.getItem('glyph_color');
-    var glyphCell = ls.getItem('glyph_cell');
+    var glyphCell = ls.getItem('glyph_cells');
     if (glyphColor !== undefined && glyphCell !== undefined) {
       // ls.setItem(..., "001122") would become number 1122 when calling ls.getItem(...)
       glyphColor = String(glyphColor);
@@ -130,7 +142,7 @@ if (Privly === undefined) {
           })
         });
         ls.removeItem('glyph_color');
-        ls.removeItem('glyph_cell');
+        ls.removeItem('glyph_cells');
       } catch (ignore) {}
     }
   };
@@ -364,7 +376,11 @@ if (Privly === undefined) {
     if (typeof glyph !== 'object' || glyph === null) {
       throw new Error('invalid argument');
     }
-    if (typeof glyph.color !== 'string' || typeof glyph.cells !== 'object' || glyph.cells === null || glyph.cells.constructor !== Array) {
+    // "glyph.cells.constructor !== Array" is not a safe check for "Array" data type.
+    // Does not work if this script(options.js) is loaded in a different global environment than
+    // glyph.js, i.e, when the scripts are loaded as CommonJS modules.
+    if (typeof glyph.color !== 'string' || typeof glyph.cells !== 'object' || 
+        glyph.cells === null || Object.prototype.toString.call(glyph.cells) !== "[object Array]") {
       throw new Error('invalid argument');
     }
     var obj = {

--- a/shared/javascripts/options.js
+++ b/shared/javascripts/options.js
@@ -307,7 +307,7 @@ if (Privly === undefined) {
    */
   Privly.options.setWhitelist = function (whitelist) {
     // typeof null === 'object'
-    if (typeof whitelist !== 'object' || whitelist === null || whitelist.constructor !== Array) {
+    if (typeof whitelist !== 'object' || whitelist === null || Object.prototype.toString.call(whitelist) !== "[object Array]") {
       throw new Error('invalid argument');
     }
     var regexp = ''; // stores regex to match validated domains

--- a/shared/javascripts/options.js
+++ b/shared/javascripts/options.js
@@ -67,9 +67,12 @@ if (Privly === undefined) {
   if (typeof module !== "undefined" && module.exports) {
     module.exports.options = Privly.options;
     // load dependencies
-    ls = require("./local_storage.js").ls;
-    Privly.storage = require("./storage.js").storage;
+    var storageModule = require("./storage.js");
+    ls = storageModule.ls;
+    Privly.storage = storageModule.storage;
     Privly.message = require("./context_messenger.js").message;
+    module.exports.storage = Privly.storage;
+    module.exports.message = Privly.message;
   }
 
 

--- a/shared/javascripts/storage.js
+++ b/shared/javascripts/storage.js
@@ -28,6 +28,13 @@ if (Privly === undefined) {
   }
   Privly.storage = {};
 
+  // CommonJS Module
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports.storage = Privly.storage;
+    // load dependencies
+    ls = require("./local_storage.js").ls;
+  }
+
   /**
    * Set an item to the storage.
    * This function doesn't return values;

--- a/shared/javascripts/storage.js
+++ b/shared/javascripts/storage.js
@@ -33,6 +33,7 @@ if (Privly === undefined) {
     module.exports.storage = Privly.storage;
     // load dependencies
     ls = require("./local_storage.js").ls;
+    module.exports.ls = ls;
   }
 
   /**

--- a/shared/test/options.js
+++ b/shared/test/options.js
@@ -60,14 +60,14 @@ describe('Privly.options', function () {
     expect(ls.getItem('posting_content_server_url')).not.toBeDefined();
 
     ls.setItem('glyph_color', '001122');
-    ls.setItem('glyph_cell', 'true,true,false,true,false,true,false,false,false,true,false,true,false,true,false');
+    ls.setItem('glyph_cells', 'true,true,false,true,false,true,false,false,false,true,false,true,false,true,false');
     Privly.options.upgrade();
     var glyph = Privly.options.getGlyph();
     expect(glyph).toEqual(jasmine.any(Object));
     expect(glyph.color).toBe('001122');
     expect(glyph.cells).toEqual([true, true, false, true, false, true, false, false, false, true, false, true, false, true, false]);
     expect(ls.getItem('glyph_color')).not.toBeDefined();
-    expect(ls.getItem('glyph_cell')).not.toBeDefined();
+    expect(ls.getItem('glyph_cells')).not.toBeDefined();
   });
 
   it('upgrade() should not change existing options if there are no old options', function () {


### PR DESCRIPTION
The changes include --
* Load the interface scripts as CommonJS modules so that they can be used in the jetpack background scripts.
* Added more functionality to the Firefox Adapter.
* Options interface bug fix.
* Changed the check for `Array` data-type in `options.js`.