### PR TITLE
Bug fix: Storage is dependent on Context Messenger

### DIFF
--- a/shared/javascripts/glyph.js
+++ b/shared/javascripts/glyph.js
@@ -49,10 +49,11 @@ if (Privly === undefined) {
 
   // CommonJS Module
   if (typeof module !== "undefined" && module.exports) {
-    module.exports.glyph = Privly.glyph;
     // load dependencies    
     var optionsModule = require("./options.js");
     Privly.options = optionsModule.options;
+    // export interfaces
+    module.exports.glyph = Privly.glyph;
     module.exports.options = optionsModule.options;
     module.exports.storage = optionsModule.storage;
     module.exports.message = optionsModule.message;

--- a/shared/javascripts/options.js
+++ b/shared/javascripts/options.js
@@ -65,12 +65,13 @@ if (Privly === undefined) {
 
   // CommonJS Module
   if (typeof module !== "undefined" && module.exports) {
-    module.exports.options = Privly.options;
     // load dependencies
     var storageModule = require("./storage.js");
     ls = storageModule.ls;
     Privly.storage = storageModule.storage;
-    Privly.message = require("./context_messenger.js").message;
+    Privly.message = storageModule.message;
+    // export interfaces
+    module.exports.options = Privly.options;
     module.exports.storage = Privly.storage;
     module.exports.message = Privly.message;
   }

--- a/shared/javascripts/storage.js
+++ b/shared/javascripts/storage.js
@@ -30,9 +30,12 @@ if (Privly === undefined) {
 
   // CommonJS Module
   if (typeof module !== "undefined" && module.exports) {
-    module.exports.storage = Privly.storage;
     // load dependencies
     ls = require("./local_storage.js").ls;
+    Privly.message = require("./context_messenger.js").message;
+    // export interfaces
+    module.exports.storage = Privly.storage;
+    module.exports.message = Privly.message;
     module.exports.ls = ls;
   }
 


### PR DESCRIPTION
I didn't notice this commit - https://github.com/privly/privly-applications/commit/91e914d0459c28bf94610fcef39552368d9178a8.
Storage is now dependent on context messenger as well. I missed out on that. My bad.