### PR TITLE
Added disable posting button to jetpack build

### DIFF
--- a/Pages/ChromeOptions.html.subtemplate
+++ b/Pages/ChromeOptions.html.subtemplate
@@ -15,7 +15,7 @@
   
   <h1 class="page-header">Extension Options</h1>
 
-{% if args.platform == "chrome" %}
+{% if args.platform == "chrome" or args.platform == "firefox" %}
   <section id="button_option">
 
     <h2>Privly Button</h2>


### PR DESCRIPTION
The selenium tests expect the ability to turn off the posting button, but you currently cannot do this from the firefox build because the option dialog was formerly only for Chrome. This fixes the html subtemplate to display the option.
