### PR TITLE
Linted some parts of code

### DIFF
--- a/Help/js/help.js
+++ b/Help/js/help.js
@@ -14,6 +14,7 @@
  * 3. Pending post: The user can make the post at this point.
  *    Callback=pendingPost
  */
+ /*global ls,privlyNetworkService */
 var callbacks = {
   
   /**

--- a/History/js/new.js
+++ b/History/js/new.js
@@ -3,6 +3,7 @@
  **/
 
 /* global historyModal:true */
+/*global privlyExtension,ls,privlyNetworkService*/
 
 /**
  * Message handlers for integration with extension framworks.

--- a/Message/js/base64.js
+++ b/Message/js/base64.js
@@ -5,6 +5,7 @@
  *  http://www.opensource.org/licenses/mit-license.php
  *
  */
+ /*jshint bitwise: false*/
 
 (function(global){
 

--- a/Message/js/zerobin.js
+++ b/Message/js/zerobin.js
@@ -22,7 +22,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  *
  */
-
+/*global Base64,RawDeflate,sjcl,i*/
 // Seed the SJCL entropy with the web crypto API or fall back to SJCL's
 // collectors
 var webCryptoEntropy = new Uint32Array(128);

--- a/shared/javascripts/extension_integration.js
+++ b/shared/javascripts/extension_integration.js
@@ -44,8 +44,8 @@ var privlyExtension = {
   messageExtension: function(handler, data) {
     
     var message = {};
-    message["handler"] = handler;
-    message["data"] = data;
+    message.handler = handler;
+    message.data = data;
     
     // Platform specific messaging
     if (privlyNetworkService.platformName() === "CHROME") {

--- a/shared/javascripts/network_service.js
+++ b/shared/javascripts/network_service.js
@@ -198,7 +198,7 @@ var privlyNetworkService = {
       if (ls.getItem('user_whitelist_csv') !== undefined) {
         ls.setItem('user_whitelist_json', 
           JSON.stringify(ls.getItem('user_whitelist_csv').split(' , ')));
-        ls.removeItem('user_whitelist_csv')
+        ls.removeItem('user_whitelist_csv');
       }
 
       // There is no local storage API on Firefox XUL

--- a/shared/javascripts/privly-web/new.js
+++ b/shared/javascripts/privly-web/new.js
@@ -59,6 +59,7 @@
  *    display it and fire the URL event.
  *    Callback=postCompleted
  */
+var messaging;
 var callbacks = {
   
   /**
@@ -264,7 +265,7 @@ var callbacks = {
 /**
  * Message handlers for integration with extension frameworks.
  */
-var messaging = {
+ messaging = {
   
   /**
    * Attach the message listeners to the interface between the extension


### PR DESCRIPTION
used global directives to avoid warnings and errors shown by jshint and jslint
changed way of accessing object properties
used concept of javascript hoisting and declared variable -'messaging' before it is used [as it is the recommended practice ]
