### PR TITLE
Add .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,5 @@
+exclude_paths:
+- vendor/**/*
+- ZeroBin/**/*
+- tests/**/*
+- */test/**/*


### PR DESCRIPTION
Added .codeclimate.yml to stop Code climate from tracking tests, ZeroBin scripts and vendor scripts.
